### PR TITLE
[hotfix] Modify hmac for compatibility of android with old version common codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation 'com.github.zaikorea:zaiclient-java:v2.1.0'
+  implementation 'com.github.zaikorea:zaiclient-java:v2.1.1'
 }
 ```
 
@@ -58,7 +58,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation("com.github.zaikorea:zaiclient-java:v2.1.0")
+  implementation("com.github.zaikorea:zaiclient-java:v2.1.1")
 }
 ```
 
@@ -81,6 +81,6 @@ dependencies {
   <dependency>
     <groupId>com.github.zaikorea</groupId>
     <artifactId>zaiclient-java</artifactId>
-    <version>v2.1.0</version>
+    <version>v2.1.1</version>
   </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zaikorea</groupId>
     <artifactId>zaiclient</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <name>ZaiClient</name>
     <url>https://github.com/zaikorea/zaiclient</url>

--- a/src/main/java/org/zaikorea/ZaiClient/security/Hmac.java
+++ b/src/main/java/org/zaikorea/ZaiClient/security/Hmac.java
@@ -20,7 +20,7 @@ public class Hmac {
         Mac mac = Mac.getInstance(algorithm);
         mac.init(secretKey);
         byte[] hash = mac.doFinal(message.getBytes());
-        return Hex.encodeHexString(hash);
+        return new String(Hex.encodeHex(hash));
     }
 
     public static String generateZaiToken(


### PR DESCRIPTION
- dependency에 common codec 버전이 추가되어 있지만, 옛날 버전의 common codec이 이미 설치가 되어 있는 경우 다시 설치하지 않기 때문에 옛날 버전에서도 호환이 가능한 함수로 hmac encoding 함수를 대체하였습니다!