### PR TITLE
[hotfix] Increase timestamp accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation 'com.github.zaikorea:zaiclient-java:v2.1.1'
+  implementation 'com.github.zaikorea:zaiclient-java:v2.1.2'
 }
 ```
 
@@ -58,7 +58,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation("com.github.zaikorea:zaiclient-java:v2.1.1")
+  implementation("com.github.zaikorea:zaiclient-java:v2.1.2")
 }
 ```
 
@@ -81,6 +81,6 @@ dependencies {
   <dependency>
     <groupId>com.github.zaikorea</groupId>
     <artifactId>zaiclient-java</artifactId>
-    <version>v2.1.1</version>
+    <version>v2.1.2</version>
   </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zaikorea</groupId>
     <artifactId>zaiclient</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 
     <name>ZaiClient</name>
     <url>https://github.com/zaikorea/zaiclient</url>

--- a/src/main/java/org/zaikorea/ZaiClient/request/Event.java
+++ b/src/main/java/org/zaikorea/ZaiClient/request/Event.java
@@ -2,7 +2,9 @@ package org.zaikorea.ZaiClient.request;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.time.Instant;
 import java.security.InvalidParameterException;
+
 
 public class Event {
 
@@ -23,7 +25,8 @@ public class Event {
     protected String eventValue;
 
     public static double getCurrentUnixTimestamp() {
-        return System.currentTimeMillis() / 1000.d;
+        Instant now = Instant.now();
+        return now.getEpochSecond() + now.getNano() / 1000000000.d;
     }
 
     public String getUserId() {

--- a/src/main/java/org/zaikorea/ZaiClient/request/EventBatch.java
+++ b/src/main/java/org/zaikorea/ZaiClient/request/EventBatch.java
@@ -3,6 +3,7 @@ package org.zaikorea.ZaiClient.request;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
+import java.time.Instant;
 
 import org.zaikorea.ZaiClient.configs.Config;
 import org.zaikorea.ZaiClient.exceptions.ItemNotFoundException;
@@ -48,7 +49,8 @@ public class EventBatch {
     }
 
     public static double getCurrentUnixTimestamp() {
-        return System.currentTimeMillis() / 1000.d;
+        Instant now = Instant.now();
+        return now.getEpochSecond() + now.getNano() / 1000000000.d;
     }
 
     public List<Event> getEventList() {


### PR DESCRIPTION
* Unix timestamp 를 사용할 때 millisecond 대신 nanosecond를 사용하도록 수정하였습니다