### PR TITLE
[hotfix] Use nanoTime instead of getNano because jdk 1.8 doesn't supp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation 'com.github.zaikorea:zaiclient-java:v2.1.3'
+  implementation 'com.github.zaikorea:zaiclient-java:v2.1.4'
 }
 ```
 
@@ -58,7 +58,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation("com.github.zaikorea:zaiclient-java:v2.1.3")
+  implementation("com.github.zaikorea:zaiclient-java:v2.1.4")
 }
 ```
 
@@ -81,6 +81,6 @@ dependencies {
   <dependency>
     <groupId>com.github.zaikorea</groupId>
     <artifactId>zaiclient-java</artifactId>
-    <version>v2.1.3</version>
+    <version>v2.1.4</version>
   </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zaikorea</groupId>
     <artifactId>zaiclient</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4</version>
 
     <name>ZaiClient</name>
     <url>https://github.com/zaikorea/zaiclient</url>

--- a/src/main/java/org/zaikorea/ZaiClient/request/Event.java
+++ b/src/main/java/org/zaikorea/ZaiClient/request/Event.java
@@ -25,8 +25,15 @@ public class Event {
     protected String eventValue;
 
     public static double getCurrentUnixTimestamp() {
-        Instant now = Instant.now();
-        return now.getEpochSecond() + now.getNano() / 1000000000.d;
+        // Have to track nanosecond because client sometimes calls api multiple times in a millisecond
+        // Use nanoTime because jdk 1.8 doesn't support Instant.getNano() function.
+        String time = Long.toString(System.nanoTime());
+        time = time.substring(time.length()-7);
+
+        long longTime = Long.parseLong(time);
+        long currentTime = System.currentTimeMillis();
+
+        return currentTime / 1000.d + longTime / 1e10;
     }
 
     public String getUserId() {

--- a/src/main/java/org/zaikorea/ZaiClient/request/EventBatch.java
+++ b/src/main/java/org/zaikorea/ZaiClient/request/EventBatch.java
@@ -49,8 +49,15 @@ public class EventBatch {
     }
 
     public static double getCurrentUnixTimestamp() {
-        Instant now = Instant.now();
-        return now.getEpochSecond() + now.getNano() / 1000000000.d;
+        // Have to track nanosecond because client sometimes calls api multiple times in a millisecond
+        // Use nanoTime because jdk 1.8 doesn't support Instant.getNano() function.
+        String time = Long.toString(System.nanoTime());
+        time = time.substring(time.length()-7);
+
+        long longTime = Long.parseLong(time);
+        long currentTime = System.currentTimeMillis();
+
+        return currentTime / 1000.d + longTime / 1e10;
     }
 
     public List<Event> getEventList() {


### PR DESCRIPTION
* jdk 1.8이 Instant.getNano()를 지원하지 않아서 System.nanoTime() 을 사용하도록 로직을 변경하였습니다