### PR TITLE
[feat] Delete legacy and add isTest

### DIFF
--- a/src/main/java/org/zaikorea/ZaiClient/ZaiAPI.java
+++ b/src/main/java/org/zaikorea/ZaiClient/ZaiAPI.java
@@ -23,21 +23,6 @@ public interface ZaiAPI {
         @Body List<Event> event
     );
 
-    @PUT(Config.eventsApiPath)
-    Call<EventLoggerResponse> updateEventLog(
-        @Body Event event
-    );
-
-    @HTTP(method="DELETE", path=Config.eventsApiPath, hasBody=true)
-    Call<EventLoggerResponse> deleteEventLog(
-        @Body Event event
-    );
-
-    @HTTP(method="DELETE", path=Config.eventsApiPath, hasBody=true)
-    Call<EventLoggerResponse> deleteEventLog(
-        @Body List<Event> event
-    );
-
     @POST
     Call<RecommendationResponse> getRecommendations(
         @Url String url,

--- a/src/main/java/org/zaikorea/ZaiClient/ZaiClient.java
+++ b/src/main/java/org/zaikorea/ZaiClient/ZaiClient.java
@@ -78,40 +78,6 @@ public class ZaiClient {
         return response.body();
     }
 
-    public EventLoggerResponse updateEventLog(Event event) throws IOException, ZaiClientException {
-        Call<EventLoggerResponse> call = zaiAPI.updateEventLog(event);
-        Response<EventLoggerResponse> response = call.execute();
-
-        if (!response.isSuccessful())
-            throw new ZaiClientException(getExceptionMessage(response), new HttpException(response));
-
-        return response.body();
-    }
-
-    public EventLoggerResponse deleteEventLog(Event event) throws IOException, ZaiClientException {
-        Call<EventLoggerResponse> call = zaiAPI.deleteEventLog(event);
-        Response<EventLoggerResponse> response = call.execute();
-
-        if (!response.isSuccessful())
-            throw new ZaiClientException(getExceptionMessage(response), new HttpException(response));
-
-        return response.body();
-    }
-
-    public EventLoggerResponse deleteEventLog(EventBatch eventBatch) throws IOException, ZaiClientException, EmptyBatchException {
-        List<Event> events = eventBatch.getEventList();
-
-        if (events.size() == 0) throw new EmptyBatchException();
-
-        Call<EventLoggerResponse> call = zaiAPI.deleteEventLog(events);
-        Response<EventLoggerResponse> response = call.execute();
-
-        if (!response.isSuccessful())
-            throw new ZaiClientException(getExceptionMessage(response), new HttpException(response));
-
-        return response.body();
-    }
-
     public RecommendationResponse getRecommendations(RecommendationRequest recommendation) throws IOException, ZaiClientException {
         Call<RecommendationResponse> call = zaiAPI.getRecommendations(
                 mlApiEndpoint + recommendation.getPath(this.zaiClientId), recommendation

--- a/src/main/java/org/zaikorea/ZaiClient/ZaiClient.java
+++ b/src/main/java/org/zaikorea/ZaiClient/ZaiClient.java
@@ -62,10 +62,47 @@ public class ZaiClient {
         return response.body();
     }
 
+    public EventLoggerResponse addEventLog(Event event, boolean isTest) throws IOException, ZaiClientException {
+        if (isTest) {
+            event.setTimeToLive(Config.testEventTimeToLive);
+        }
+        
+        Call<EventLoggerResponse> call = zaiAPI.addEventLog(event);
+
+        Response<EventLoggerResponse> response = call.execute();
+
+        if (!response.isSuccessful())
+            throw new ZaiClientException(getExceptionMessage(response), new HttpException(response));
+
+        return response.body();
+    }
+
     public EventLoggerResponse addEventLog(EventBatch eventBatch) throws IOException, ZaiClientException, EmptyBatchException {
         List<Event> events = eventBatch.getEventList();
 
         if (events.size() == 0) throw new EmptyBatchException();
+
+        Call<EventLoggerResponse> call = zaiAPI.addEventLog(events);
+        Response<EventLoggerResponse> response = call.execute();
+
+        if (!response.isSuccessful())
+            throw new ZaiClientException(getExceptionMessage(response), new HttpException(response));
+
+        eventBatch.setLogFlag();
+
+        return response.body();
+    }
+
+    public EventLoggerResponse addEventLog(EventBatch eventBatch, boolean isTest) throws IOException, ZaiClientException, EmptyBatchException {
+        List<Event> events = eventBatch.getEventList();
+
+        if (events.size() == 0) throw new EmptyBatchException();
+
+        if (isTest) {
+            for (Event event : events) {
+                event.setTimeToLive(Config.testEventTimeToLive);
+            }
+        }
 
         Call<EventLoggerResponse> call = zaiAPI.addEventLog(events);
         Response<EventLoggerResponse> response = call.execute();

--- a/src/main/java/org/zaikorea/ZaiClient/configs/Config.java
+++ b/src/main/java/org/zaikorea/ZaiClient/configs/Config.java
@@ -20,4 +20,5 @@ public class Config {
     
     public static final int batchRequestCap = 50;
     public static final double epsilon = 1e-4;
+    public static final int testEventTimeToLive = 60 * 60 * 24; // 1 day
 }

--- a/src/main/java/org/zaikorea/ZaiClient/request/Event.java
+++ b/src/main/java/org/zaikorea/ZaiClient/request/Event.java
@@ -23,6 +23,9 @@ public class Event {
     @SerializedName("event_value")
     protected String eventValue;
 
+    @SerializedName("time_to_live")
+    protected Integer timeToLive = null;
+
     public static double getCurrentUnixTimestamp() {
         // Have to track nanosecond because client sometimes calls api multiple times in a millisecond
         // Use nanoTime because jdk 1.8 doesn't support Instant.getNano() function.
@@ -53,6 +56,10 @@ public class Event {
 
     public String getEventValue() {
         return eventValue;
+    }
+
+    public Integer getTimeToLive() {
+        return timeToLive;
     }
 
     public void setUserId(String userId) {
@@ -91,5 +98,12 @@ public class Event {
             this.eventValue = eventValue.substring(0, 500);
         else
             this.eventValue = eventValue;
+    }
+
+    public void setTimeToLive(int timeToLive) {
+        if (timeToLive < 0)
+            throw new InvalidParameterException("Time value can not be negative.");
+        
+        this.timeToLive = timeToLive;
     }
 }

--- a/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientBatchJavaTest.java
+++ b/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientBatchJavaTest.java
@@ -202,6 +202,9 @@ public class ZaiClientBatchJavaTest {
         ddbClient.close();
     }
 
+    /**********************************
+    *        PurchaseEventBatch       *
+    ***********************************/
     @Test
     public void testAddPurchaseEventBatch() {
         String userId = generateUUID();
@@ -359,6 +362,9 @@ public class ZaiClientBatchJavaTest {
         }
     }
 
+    /**********************************
+    *         CustomEventBatch        *
+    ***********************************/
     @Test
     public void testAddCustomEventBatch() {
         String userId = generateUUID();

--- a/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientBatchJavaTest.java
+++ b/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientBatchJavaTest.java
@@ -134,45 +134,6 @@ public class ZaiClientBatchJavaTest {
         }
     }
 
-    private void checkSuccessfulEventBatchDelete(EventBatch eventBatch) {
-        try {
-            testClient.addEventLog(eventBatch);
-
-            List<Event> events = eventBatch.getEventList();
-
-            for (Event event : events) {
-
-                String userId = event.getUserId();
-                double timestamp = event.getTimestamp();
-                String itemId = event.getItemId();
-                String eventType = event.getEventType();
-                String eventValue = event.getEventValue();
-
-                Map<String, String> logItem = getEventLogWithTimestamp(userId, timestamp);
-                assertNotNull(logItem);
-                assertNotEquals(logItem.size(), 0);
-                assertEquals(logItem.get(eventTablePartitionKey), userId);
-                assertEquals(logItem.get(eventTableItemIdKey), itemId);
-                assertEquals(Double.parseDouble(logItem.get(eventTableSortKey)), timestamp, 0.0001);
-                assertEquals(logItem.get(eventTableEventTypeKey), eventType);
-                assertEquals(logItem.get(eventTableEventValueKey), eventValue);
-            }
-
-            testClient.deleteEventLog(eventBatch);
-
-            for (Event event : events) {
-                String userId = event.getUserId();
-                double timestamp = event.getTimestamp();
-
-                Map<String, String> newLogItem = getEventLogWithTimestamp(userId, timestamp);
-                assertNotNull(newLogItem);
-                assertEquals(newLogItem.size(), 0);
-            }
-        } catch (IOException | ZaiClientException | EmptyBatchException e) {
-            fail();
-        }
-    }
-
     public static String getUnixTimestamp() {
         long utcnow = Instant.now().getEpochSecond();
         return Long.toString(utcnow);
@@ -296,27 +257,6 @@ public class ZaiClientBatchJavaTest {
     }
 
     @Test
-    public void testDeletePurchaseEventBatch() {
-        String userId = generateUUID();
-
-        try {
-            PurchaseEventBatch eventBatch = new PurchaseEventBatch(userId);
-
-            final int NUM = 10;
-
-            for (int i = 0; i < NUM ; i++) {
-                String itemId = generateUUID();
-                int price = generateRandomInteger(10000, 100000);
-
-                eventBatch.addEventItem(itemId, price);
-            }
-            checkSuccessfulEventBatchDelete(eventBatch);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    @Test
     public void testAddPurchaseEventBatchExceedMaxLimit() {
         String userId = generateUUID();
 
@@ -431,28 +371,6 @@ public class ZaiClientBatchJavaTest {
             eventBatch.deleteEventItem(itemId, eventValue);
 
             checkSuccessfulEventBatchAdd(eventBatch);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    @Test
-    public void testDeleteCustomEventBatch() {
-        String userId = generateUUID();
-        String eventType = "customEventType";
-
-        try {
-            CustomEventBatch eventBatch = new CustomEventBatch(userId, eventType);
-
-            final int NUM = 10;
-
-            for (int i = 0; i < NUM ; i++) {
-                String itemId = generateUUID();
-                double rate = generateRandomDouble(0, 5);
-
-                eventBatch.addEventItem(itemId, Double.toString(rate));
-            }
-            checkSuccessfulEventBatchDelete(eventBatch);
         } catch (Exception e) {
             fail();
         }

--- a/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientJavaTest.java
+++ b/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientJavaTest.java
@@ -181,77 +181,6 @@ public class ZaiClientJavaTest {
         }
     }
 
-    private void checkSuccessfulEventUpdate(Event oldEvent, Event newEvent) {
-        assertEquals(oldEvent.getUserId(), newEvent.getUserId());
-        assertEquals(oldEvent.getTimestamp(), newEvent.getTimestamp(), 0.0001);
-
-        try {
-            testClient.addEventLog(oldEvent);
-            String userId = oldEvent.getUserId();
-            double timestamp = oldEvent.getTimestamp();
-            String itemId = oldEvent.getItemId();
-            String eventType = oldEvent.getEventType();
-            String eventValue = oldEvent.getEventValue();
-
-            Map<String, String> logItem = getEventLog(userId);
-            assertNotNull(logItem);
-            assertNotEquals(logItem.size(), 0);
-            assertEquals(logItem.get(eventTablePartitionKey), userId);
-            assertEquals(logItem.get(eventTableItemIdKey), itemId);
-            assertEquals(Double.parseDouble(logItem.get(eventTableSortKey)), timestamp, 0.0001);
-            assertEquals(logItem.get(eventTableEventTypeKey), eventType);
-            assertEquals(logItem.get(eventTableEventValueKey), eventValue);
-
-            testClient.updateEventLog(newEvent);
-            userId = newEvent.getUserId();
-            timestamp = newEvent.getTimestamp();
-            itemId = newEvent.getItemId();
-            eventType = newEvent.getEventType();
-            eventValue = newEvent.getEventValue();
-
-            logItem = getEventLog(userId);
-            assertNotNull(logItem);
-            assertNotEquals(logItem.size(), 0);
-            assertEquals(logItem.get(eventTablePartitionKey), userId);
-            assertEquals(logItem.get(eventTableItemIdKey), itemId);
-            assertEquals(Double.parseDouble(logItem.get(eventTableSortKey)), timestamp, 0.0001);
-            assertEquals(logItem.get(eventTableEventTypeKey), eventType);
-            assertEquals(logItem.get(eventTableEventValueKey), eventValue);
-
-            assertTrue(deleteEventLog(userId));
-        } catch (IOException | ZaiClientException e) {
-            fail();
-        }
-    }
-
-    private void checkSuccessfulEventDelete(Event event) {
-        try {
-            testClient.addEventLog(event);
-            String userId = event.getUserId();
-            double timestamp = event.getTimestamp();
-            String itemId = event.getItemId();
-            String eventType = event.getEventType();
-            String eventValue = event.getEventValue();
-
-            Map<String, String> logItem = getEventLog(userId);
-            assertNotNull(logItem);
-            assertNotEquals(logItem.size(), 0);
-            assertEquals(logItem.get(eventTablePartitionKey), userId);
-            assertEquals(logItem.get(eventTableItemIdKey), itemId);
-            assertEquals(Double.parseDouble(logItem.get(eventTableSortKey)), timestamp, 0.0001);
-            assertEquals(logItem.get(eventTableEventTypeKey), eventType);
-            assertEquals(logItem.get(eventTableEventValueKey), eventValue);
-
-            testClient.deleteEventLog(event);
-
-            Map<String, String> newLogItem = getEventLog(userId);
-            assertNotNull(newLogItem);
-            assertEquals(newLogItem.size(), 0);
-        } catch (IOException | ZaiClientException e) {
-            fail();
-        }
-    }
-
     @Before
     public void setup() {
         testClient = new ZaiClient.Builder(clientId, clientSecret)
@@ -352,26 +281,6 @@ public class ZaiClientJavaTest {
     }
 
     @Test
-    public void testUpdateViewEvent() {
-        String userId = generateUUID();
-        String oldItemId = generateUUID();
-        String newItemId = generateUUID();
-
-        Event oldEvent = new ViewEvent(userId, oldItemId);
-        Event newEvent = new ViewEvent(userId, newItemId, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeleteViewEvent() {
-        String userId = generateUUID();
-        String itemId = generateUUID();
-
-        Event event = new ViewEvent(userId, itemId);
-        checkSuccessfulEventDelete(event);
-    }
-
-    @Test
     public void testAddProductDetailViewEvent() {
         String userId = generateUUID();
         String itemId = generateUUID();
@@ -420,26 +329,6 @@ public class ZaiClientJavaTest {
         } catch (ZaiClientException e) {
             assertEquals(e.getHttpStatusCode(), 401);
         }
-    }
-
-    @Test
-    public void testUpdateProductDetailViewEvent() {
-        String userId = generateUUID();
-        String oldItemId = generateUUID();
-        String newItemId = generateUUID();
-
-        Event oldEvent = new ProductDetailViewEvent(userId, oldItemId);
-        Event newEvent = new ProductDetailViewEvent(userId, newItemId, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeleteProductDetailViewEvent() {
-        String userId = generateUUID();
-        String itemId = generateUUID();
-
-        Event event = new ProductDetailViewEvent(userId, itemId);
-        checkSuccessfulEventDelete(event);
     }
 
     @Test
@@ -494,26 +383,6 @@ public class ZaiClientJavaTest {
     }
 
     @Test
-    public void testUpdateLikeEvent() {
-        String userId = generateUUID();
-        String oldItemId = generateUUID();
-        String newItemId = generateUUID();
-
-        Event oldEvent = new LikeEvent(userId, oldItemId);
-        Event newEvent = new LikeEvent(userId, newItemId, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeleteLikeEvent() {
-        String userId = generateUUID();
-        String itemId = generateUUID();
-
-        Event event = new LikeEvent(userId, itemId);
-        checkSuccessfulEventDelete(event);
-    }
-
-    @Test
     public void testAddPageViewEvent() {
         String userId = generateUUID();
         String pageType = generatePageType();
@@ -562,17 +431,6 @@ public class ZaiClientJavaTest {
         } catch (ZaiClientException e) {
             assertEquals(e.getHttpStatusCode(), 401);
         }
-    }
-
-    @Test
-    public void testUpdatePageViewEvent() {
-        String userId = generateUUID();
-        String oldpageType = generatePageType();
-        String newpageType = generatePageType();
-
-        Event oldEvent = new PageViewEvent(userId, oldpageType);
-        Event newEvent = new PageViewEvent(userId, newpageType, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
     }
 
     @Test
@@ -627,35 +485,6 @@ public class ZaiClientJavaTest {
     }
 
     @Test
-    public void testUpdateSearchEvent() {
-        String userId = generateUUID();
-        String oldsearchQuery = generateSearchQuery();
-        String newsearchQuery = generateSearchQuery();
-
-        Event oldEvent = new SearchEvent(userId, oldsearchQuery);
-        Event newEvent = new SearchEvent(userId, newsearchQuery, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeleteSearchEvent() {
-        String userId = generateUUID();
-        String searchQuery = generateSearchQuery();
-
-        Event event = new SearchEvent(userId, searchQuery);
-        checkSuccessfulEventDelete(event);
-    }
-
-    @Test
-    public void testDeletePageViewEvent() {
-        String userId = generateUUID();
-        String pageType = generateUUID();
-
-        Event event = new PageViewEvent(userId, pageType);
-        checkSuccessfulEventDelete(event);
-    }
-
-    @Test
     public void testAddCartaddEvent() {
         String userId = generateUUID();
         String itemId = generateUUID();
@@ -704,26 +533,6 @@ public class ZaiClientJavaTest {
         } catch (ZaiClientException e) {
             assertEquals(e.getHttpStatusCode(), 401);
         }
-    }
-
-    @Test
-    public void testUpdateCartaddEvent() {
-        String userId = generateUUID();
-        String oldItemId = generateUUID();
-        String newItemId = generateUUID();
-
-        Event oldEvent = new CartaddEvent(userId, oldItemId);
-        Event newEvent = new CartaddEvent(userId, newItemId, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeleteCartaddEvent() {
-        String userId = generateUUID();
-        String itemId = generateUUID();
-
-        Event event = new CartaddEvent(userId, itemId);
-        checkSuccessfulEventDelete(event);
     }
 
     @Test
@@ -782,29 +591,6 @@ public class ZaiClientJavaTest {
     }
 
     @Test
-    public void testUpdateRateEvent() {
-        String userId = generateUUID();
-        double oldRating = generateRandomDouble(0, 5);
-        String oldItemId = generateUUID();
-        double newRating = generateRandomDouble(0, 5);
-        String newItemId = generateUUID();
-
-        Event oldEvent = new RateEvent(userId, oldItemId, oldRating);
-        Event newEvent = new RateEvent(userId, newItemId, newRating, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeleteRateEvent() {
-        String userId = generateUUID();
-        String itemId = generateUUID();
-        double rating = generateRandomDouble(0, 5);
-
-        Event event = new RateEvent(userId, itemId, rating);
-        checkSuccessfulEventDelete(event);
-    }
-
-    @Test
     public void testAddPurchaseEvent() {
         String userId = generateUUID();
         String itemId = generateUUID();
@@ -860,29 +646,6 @@ public class ZaiClientJavaTest {
     }
 
     @Test
-    public void testUpdatePurchaseEvent() {
-        String userId = generateUUID();
-        int oldPrice = generateRandomInteger(10000, 100000);
-        String oldItemId = generateUUID();
-        int newPrice = generateRandomInteger(10000, 100000);
-        String newItemId = generateUUID();
-
-        Event oldEvent = new PurchaseEvent(userId, oldItemId, oldPrice);
-        Event newEvent = new PurchaseEvent(userId, newItemId, newPrice, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeletePurchaseEvent() {
-        String userId = generateUUID();
-        String itemId = generateUUID();
-        int price = generateRandomInteger(10000, 100000);
-
-        Event event = new PurchaseEvent(userId, itemId, price);
-        checkSuccessfulEventDelete(event);
-    }
-
-    @Test
     public void testAddCustomEvent() {
         String userId = generateUUID();
         String itemId = generateUUID();
@@ -903,32 +666,6 @@ public class ZaiClientJavaTest {
 
         Event event = new CustomEvent(userId, itemId, eventType, eventValue, timestamp);
         checkSuccessfulEventAdd(event);
-    }
-
-    @Test
-    public void testUpdateCustomEvent() {
-        String userId = generateUUID();
-        String oldItemId = generateUUID();
-        String oldEventType = "oldEventType";
-        String oldEventValue = "oldEventValue";
-        String newItemId = generateUUID();
-        String newEventType = "newEventType";
-        String newEventValue = "newEventValue";
-
-        Event oldEvent = new CustomEvent(userId, oldItemId, oldEventType, oldEventValue);
-        Event newEvent = new CustomEvent(userId, newItemId, newEventType, newEventValue, oldEvent.getTimestamp());
-        checkSuccessfulEventUpdate(oldEvent, newEvent);
-    }
-
-    @Test
-    public void testDeleteCustomEvent() {
-        String userId = generateUUID();
-        String itemId = generateUUID();
-        String eventType = "customEventType";
-        String eventValue = "customEventValue";
-
-        Event event = new CustomEvent(userId, itemId, eventType, eventValue);
-        checkSuccessfulEventDelete(event);
     }
 
     @Test

--- a/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientJavaTest.java
+++ b/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientJavaTest.java
@@ -30,9 +30,12 @@ public class ZaiClientJavaTest {
     private static final String eventTableItemIdKey = "item_id";
     private static final String eventTableEventTypeKey = "event_type";
     private static final String eventTableEventValueKey = "event_value";
+    private static final String eventTableExpirationTimeKey = "expiration_time";
 
     private static final String incorrectCustomEndpointMsg = "Only alphanumeric characters are allowed for custom endpoint.";
     private static final String longLengthCustomEndpointMsg = "Custom endpoint should be less than or equal to 10.";
+
+    private static final int defaultDataExpirationSeconds = 60 * 60 * 24 * 365; // 1 year
 
     private ZaiClient testClient;
     private ZaiClient incorrectIdClient;
@@ -181,6 +184,36 @@ public class ZaiClientJavaTest {
         }
     }
 
+    private void checkSuccessfulEventAdd(Event event, boolean isTest) {
+        try {
+            testClient.addEventLog(event, isTest);
+            String userId = event.getUserId();
+            double timestamp = event.getTimestamp();
+            String itemId = event.getItemId();
+            String eventType = event.getEventType();
+            String eventValue = event.getEventValue();
+            Integer timeToLive = event.getTimeToLive();
+
+            Map<String, String> logItem = getEventLog(userId);
+            assertNotNull(logItem);
+            assertNotEquals(logItem.size(), 0);
+            assertEquals(logItem.get(eventTablePartitionKey), userId);
+            assertEquals(logItem.get(eventTableItemIdKey), itemId);
+            assertEquals(Double.parseDouble(logItem.get(eventTableSortKey)), timestamp, 0.0001);
+            assertEquals(logItem.get(eventTableEventTypeKey), eventType);
+            assertEquals(logItem.get(eventTableEventValueKey), eventValue);
+            if (isTest) {
+                assertEquals(Integer.parseInt(logItem.get(eventTableExpirationTimeKey)), (int) (timestamp + timeToLive), 1);
+            }
+            else {
+                assertEquals(Integer.parseInt(logItem.get(eventTableExpirationTimeKey)), (int) (timestamp + defaultDataExpirationSeconds), 1);
+            }
+            assertTrue(deleteEventLog(userId));
+        } catch (IOException | ZaiClientException e) {
+            fail();
+        }
+    }
+
     @Before
     public void setup() {
         testClient = new ZaiClient.Builder(clientId, clientSecret)
@@ -239,6 +272,24 @@ public class ZaiClientJavaTest {
     }
 
     @Test
+    public void testAddTrueTestViewEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new ViewEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestViewEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new ViewEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, false);
+    }
+
+    @Test
     public void testAddViewEventManualTime() {
         String userId = generateUUID();
         String itemId = generateUUID();
@@ -287,6 +338,24 @@ public class ZaiClientJavaTest {
 
         Event event = new ProductDetailViewEvent(userId, itemId);
         checkSuccessfulEventAdd(event);
+    }
+
+    @Test
+    public void testAddTrueTestProductDetailViewEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new ProductDetailViewEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestProductDetailViewEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new ProductDetailViewEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, false);
     }
 
     @Test
@@ -341,6 +410,24 @@ public class ZaiClientJavaTest {
     }
 
     @Test
+    public void testAddTrueTestLikeEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new LikeEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestLikeEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new LikeEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, false);
+    }
+
+    @Test
     public void testAddLikeEventManualTime() {
         String userId = generateUUID();
         String itemId = generateUUID();
@@ -389,6 +476,24 @@ public class ZaiClientJavaTest {
 
         Event event = new PageViewEvent(userId, pageType);
         checkSuccessfulEventAdd(event);
+    }
+    
+    @Test
+    public void testAddTrueTestPageViewEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new PageViewEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestPageViewEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new PageViewEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, false);
     }
 
     @Test
@@ -443,6 +548,24 @@ public class ZaiClientJavaTest {
     }
 
     @Test
+    public void testAddTrueTestSearchEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new SearchEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestSearchEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new SearchEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, false);
+    }
+
+    @Test
     public void testAddSearchEventManualTime() {
         String userId = generateUUID();
         String searchQuery = generateSearchQuery();
@@ -491,6 +614,24 @@ public class ZaiClientJavaTest {
 
         Event event = new CartaddEvent(userId, itemId);
         checkSuccessfulEventAdd(event);
+    }
+
+    @Test
+    public void testAddTrueTestCartaddEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new CartaddEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestCartaddEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+
+        Event event = new CartaddEvent(userId, itemId);
+        checkSuccessfulEventAdd(event, false);
     }
 
     @Test
@@ -543,6 +684,26 @@ public class ZaiClientJavaTest {
 
         Event event = new RateEvent(userId, itemId, rating);
         checkSuccessfulEventAdd(event);
+    }
+
+    @Test
+    public void testAddTrueTestRateEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+        double rating = generateRandomDouble(0, 5);
+
+        Event event = new RateEvent(userId, itemId, rating);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestRateEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+        double rating = generateRandomDouble(0, 5);
+
+        Event event = new RateEvent(userId, itemId, rating);
+        checkSuccessfulEventAdd(event, false);
     }
 
     @Test
@@ -601,6 +762,26 @@ public class ZaiClientJavaTest {
     }
 
     @Test
+    public void testAddTrueTestPurchaseEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+        int price = generateRandomInteger(10000, 100000);
+
+        Event event = new PurchaseEvent(userId, itemId, price);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseTestPurchaseEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+        int price = generateRandomInteger(10000, 100000);
+
+        Event event = new PurchaseEvent(userId, itemId, price);
+        checkSuccessfulEventAdd(event, false);
+    }
+
+    @Test
     public void testAddPurchaseEventManualTime() {
         String userId = generateUUID();
         String itemId = generateUUID();
@@ -654,6 +835,28 @@ public class ZaiClientJavaTest {
 
         Event event = new CustomEvent(userId, itemId, eventType, eventValue);
         checkSuccessfulEventAdd(event);
+    }
+
+    @Test
+    public void testAddTrueTestCustomEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+        String eventType = "customEventType";
+        String eventValue = "customEventValue";
+
+        Event event = new CustomEvent(userId, itemId, eventType, eventValue);
+        checkSuccessfulEventAdd(event, true);
+    }
+
+    @Test
+    public void testAddFalseCustomEvent() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+        String eventType = "customEventType";
+        String eventValue = "customEventValue";
+
+        Event event = new CustomEvent(userId, itemId, eventType, eventValue);
+        checkSuccessfulEventAdd(event, false);
     }
 
     @Test
@@ -771,6 +974,21 @@ public class ZaiClientJavaTest {
         String eventValue = "";
         try {
             Event event = new CustomEvent(userId, itemId, eventType, eventValue);
+        } catch(InvalidParameterException e) {
+            return ;
+        }
+        fail();
+    }
+
+    @Test
+    public void testNegativeTimeToLive() {
+        String userId = generateUUID();
+        String itemId = generateUUID();
+        String eventType = generateUUID();
+        String eventValue = "";
+        try {
+            Event event = new CustomEvent(userId, itemId, eventType, eventValue);
+            event.setTimeToLive(-defaultDataExpirationSeconds);
         } catch(InvalidParameterException e) {
             return ;
         }

--- a/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientJavaTest.java
+++ b/src/test/java/org/zaikorea/ZaiClientTest/ZaiClientJavaTest.java
@@ -1,7 +1,6 @@
 package org.zaikorea.ZaiClientTest;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.security.InvalidParameterException;
 import java.time.Instant;
 import java.util.*;
@@ -262,6 +261,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *             ViewEvent           *
+    ***********************************/
     @Test
     public void testAddViewEvent() {
         String userId = generateUUID();
@@ -331,6 +333,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *      ProductDetailViewEvent     *
+    ***********************************/
     @Test
     public void testAddProductDetailViewEvent() {
         String userId = generateUUID();
@@ -400,6 +405,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *            LikeEvent            *
+    ***********************************/
     @Test
     public void testAddLikeEvent() {
         String userId = generateUUID();
@@ -469,6 +477,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *          PageViewEvent          *
+    ***********************************/
     @Test
     public void testAddPageViewEvent() {
         String userId = generateUUID();
@@ -538,6 +549,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *           SearchEvent           *
+    ***********************************/
     @Test
     public void testAddSearchEvent() {
         String userId = generateUUID();
@@ -607,6 +621,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *           CartaddEvent          *
+    ***********************************/
     @Test
     public void testAddCartaddEvent() {
         String userId = generateUUID();
@@ -676,6 +693,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *            RateEvent            *
+    ***********************************/
     @Test
     public void testAddRateEvent() {
         String userId = generateUUID();
@@ -751,6 +771,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *          PurchaseEvent          *
+    ***********************************/
     @Test
     public void testAddPurchaseEvent() {
         String userId = generateUUID();
@@ -826,6 +849,9 @@ public class ZaiClientJavaTest {
         }
     }
 
+    /**********************************
+    *           CustomEvent           *
+    ***********************************/
     @Test
     public void testAddCustomEvent() {
         String userId = generateUUID();

--- a/src/test/kotlin/org/zaikorea/ZaiClientTest/ZaiClientBatchKotlinTest.kt
+++ b/src/test/kotlin/org/zaikorea/ZaiClientTest/ZaiClientBatchKotlinTest.kt
@@ -121,55 +121,17 @@ class ZaiClientBatchKotlinTest {
         }
     }
 
-    private fun checkSuccessfulEventBatchDelete(eventBatch: EventBatch) {
-        try {
-            testClient!!.addEventLog(eventBatch)
-            val events = eventBatch.eventList
-            for (event in events) {
-                val userId = event.userId
-                val timestamp = event.timestamp
-                val itemId = event.itemId
-                val eventType = event.eventType
-                val eventValue = event.eventValue
-                val logItem = getEventLogWithTimestamp(userId, timestamp)
-                Assert.assertNotNull(logItem)
-                Assert.assertNotEquals(logItem!!.size.toLong(), 0)
-                Assert.assertEquals(logItem[eventTablePartitionKey], userId)
-                Assert.assertEquals(logItem[eventTableItemIdKey], itemId)
-                Assert.assertEquals(
-                    logItem[eventTableSortKey]!!.toDouble(), timestamp, 0.0001
-                )
-                Assert.assertEquals(logItem[eventTableEventTypeKey], eventType)
-                Assert.assertEquals(logItem[eventTableEventValueKey], eventValue)
-            }
-            testClient!!.deleteEventLog(eventBatch)
-            for (event in events) {
-                val userId = event.userId
-                val timestamp = event.timestamp
-                val newLogItem = getEventLogWithTimestamp(userId, timestamp)
-                Assert.assertNotNull(newLogItem)
-                Assert.assertEquals(newLogItem!!.size.toLong(), 0)
-            }
-        } catch (e: IOException) {
-            Assert.fail()
-        } catch (e: ZaiClientException) {
-            Assert.fail()
-        } catch (e: EmptyBatchException) {
-            Assert.fail()
-        }
-    }
-
     @Before
     fun setup() {
         testClient = ZaiClient.Builder(clientId, clientSecret)
             .connectTimeout(30)
             .readTimeout(10)
             .build()
-        incorrectIdClient = ZaiClient.Builder("." + clientId, clientSecret)
+        incorrectIdClient = ZaiClient.Builder(".$clientId", clientSecret)
             .connectTimeout(0)
             .readTimeout(0)
             .build()
-        incorrectSecretClient = ZaiClient.Builder(clientId, "." + clientSecret)
+        incorrectSecretClient = ZaiClient.Builder(clientId, ".$clientSecret")
             .connectTimeout(-1)
             .readTimeout(-1)
             .build()
@@ -259,23 +221,6 @@ class ZaiClientBatchKotlinTest {
     }
 
     @Test
-    fun testDeletePurchaseEventBatch() {
-        val userId = generateUUID()
-        try {
-            val eventBatch = PurchaseEventBatch(userId)
-            val NUM = 10
-            for (i in 0 until NUM) {
-                val itemId = generateUUID()
-                val price = generateRandomInteger(10000, 100000)
-                eventBatch.addEventItem(itemId, price)
-            }
-            checkSuccessfulEventBatchDelete(eventBatch)
-        } catch (e: Exception) {
-            Assert.fail()
-        }
-    }
-
-    @Test
     fun testAddPurchaseEventBatchExceedMaxLimit() {
         val userId = generateUUID()
         try {
@@ -302,7 +247,7 @@ class ZaiClientBatchKotlinTest {
             for (i in 0 until NUM) {
                 val itemId = generateUUID()
                 val rate = generateRandomDouble(0, 5)
-                eventBatch.addEventItem(itemId, java.lang.Double.toString(rate))
+                eventBatch.addEventItem(itemId, rate.toString())
             }
             checkSuccessfulEventBatchAdd(eventBatch)
         } catch (e: Exception) {
@@ -321,7 +266,7 @@ class ZaiClientBatchKotlinTest {
             for (i in 0 until NUM) {
                 val itemId = generateUUID()
                 val rate = generateRandomDouble(0, 5)
-                eventBatch.addEventItem(itemId, java.lang.Double.toString(rate))
+                eventBatch.addEventItem(itemId, rate.toString())
             }
             checkSuccessfulEventBatchAdd(eventBatch)
         } catch (e: Exception) {
@@ -341,7 +286,7 @@ class ZaiClientBatchKotlinTest {
             val NUM = 10
             for (i in 0 until NUM) {
                 itemId = generateUUID()
-                eventValue = java.lang.Double.toString(generateRandomDouble(0, 5))
+                eventValue = generateRandomDouble(0, 5).toString()
                 eventBatch.addEventItem(itemId, eventValue)
             }
             eventBatch.deleteEventItem(itemId)
@@ -363,29 +308,11 @@ class ZaiClientBatchKotlinTest {
             val NUM = 10
             for (i in 0 until NUM) {
                 itemId = generateUUID()
-                eventValue = java.lang.Double.toString(generateRandomDouble(0, 5))
+                eventValue = generateRandomDouble(0, 5).toString()
                 eventBatch.addEventItem(itemId, eventValue)
             }
             eventBatch.deleteEventItem(itemId, eventValue)
             checkSuccessfulEventBatchAdd(eventBatch)
-        } catch (e: Exception) {
-            Assert.fail()
-        }
-    }
-
-    @Test
-    fun testDeleteCustomEventBatch() {
-        val userId = generateUUID()
-        val eventType = "customEventType"
-        try {
-            val eventBatch = CustomEventBatch(userId, eventType)
-            val NUM = 10
-            for (i in 0 until NUM) {
-                val itemId = generateUUID()
-                val rate = generateRandomDouble(0, 5)
-                eventBatch.addEventItem(itemId, java.lang.Double.toString(rate))
-            }
-            checkSuccessfulEventBatchDelete(eventBatch)
         } catch (e: Exception) {
             Assert.fail()
         }
@@ -401,7 +328,7 @@ class ZaiClientBatchKotlinTest {
             for (i in 0 until NUM) {
                 val itemId = generateUUID()
                 val rate = generateRandomDouble(0, 5)
-                eventBatch.addEventItem(itemId, java.lang.Double.toString(rate))
+                eventBatch.addEventItem(itemId, rate.toString())
             }
             checkSuccessfulEventBatchAdd(eventBatch)
         } catch (e: Exception) {
@@ -424,7 +351,7 @@ class ZaiClientBatchKotlinTest {
         val unixTimestamp: String
             get() {
                 val utcnow = Instant.now().epochSecond
-                return java.lang.Long.toString(utcnow)
+                return utcnow.toString()
             }
     }
 }

--- a/src/test/kotlin/org/zaikorea/ZaiClientTest/ZaiClientKotlinTest.kt
+++ b/src/test/kotlin/org/zaikorea/ZaiClientTest/ZaiClientKotlinTest.kt
@@ -140,6 +140,40 @@ class ZaiClientKotlinTest {
         }
     }
 
+    private fun checkSuccessfulEventAdd(event: Event, isTest: Boolean) {
+        try {
+            testClient!!.addEventLog(event, isTest)
+            val userId = event.userId
+            val timestamp = event.timestamp
+            val itemId = event.itemId
+            val eventType = event.eventType
+            val eventValue = event.eventValue
+            val timeToLive: Int? = event.timeToLive
+            val logItem = getEventLog(userId)
+
+            Assert.assertNotNull(logItem)
+            Assert.assertNotEquals(logItem!!.size.toLong(), 0)
+            Assert.assertEquals(logItem[eventTablePartitionKey], userId)
+            Assert.assertEquals(logItem[eventTableItemIdKey], itemId)
+            Assert.assertEquals(logItem[eventTableSortKey]!!.toDouble(), timestamp, 0.0001)
+            Assert.assertEquals(logItem[eventTableEventTypeKey], eventType)
+            Assert.assertEquals(logItem[eventTableEventValueKey], eventValue)
+            if (isTest) {
+                Assert.assertEquals(logItem[eventTableExpirationTimeKey]!!.toDouble(),
+                        (timestamp + timeToLive!!).toInt().toDouble(), 1.0)
+            }
+            else {
+                Assert.assertEquals(logItem[eventTableExpirationTimeKey]!!.toDouble(),
+                        (timestamp + defaultDataExpirationSeconds).toInt().toDouble(), 1.0)
+            }
+            Assert.assertTrue(deleteEventLog(userId))
+        } catch (e: IOException) {
+            Assert.fail()
+        } catch (e: ZaiClientException) {
+            Assert.fail()
+        }
+    }
+
     @Before
     fun setup() {
         testClient = ZaiClient.Builder(clientId, clientSecret)
@@ -190,12 +224,31 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *            ViewEvent           *
+     **********************************/
     @Test
     fun testAddViewEvent() {
         val userId = generateUUID()
         val itemId = generateUUID()
         val event: Event = ViewEvent(userId, itemId)
         checkSuccessfulEventAdd(event)
+    }
+
+    @Test
+    fun testTrueTestAddViewEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = ViewEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testFalseTestAddViewEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = ViewEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -237,6 +290,9 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *     ProductDetailViewEvent     *
+     **********************************/
     @Test
     fun testAddProductDetailViewEventManualTime() {
         val userId = generateUUID()
@@ -244,6 +300,22 @@ class ZaiClientKotlinTest {
         val timestamp = unixTimestamp.toLong()
         val event: Event = ProductDetailViewEvent(userId, itemId, timestamp.toDouble())
         checkSuccessfulEventAdd(event)
+    }
+
+    @Test
+    fun testAddTrueTestProductDetailViewEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = ProductDetailViewEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestProductDetailViewEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = ProductDetailViewEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -274,6 +346,25 @@ class ZaiClientKotlinTest {
         } catch (e: ZaiClientException) {
             Assert.assertEquals(401, e.httpStatusCode.toLong())
         }
+    }
+
+    /**********************************
+     *          PageViewEvent         *
+     **********************************/
+    @Test
+    fun testAddTrueTestPageViewEvent() {
+        val userId = generateUUID()
+        val pageType = generatePageType()
+        val event: Event = PageViewEvent(userId, pageType)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestPageViewEvent() {
+        val userId = generateUUID()
+        val pageType = generatePageType()
+        val event: Event = PageViewEvent(userId, pageType)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -315,12 +406,31 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *            LikeEvent           *
+     **********************************/
     @Test
     fun testAddLikeEvent() {
         val userId = generateUUID()
         val itemId = generateUUID()
         val event: Event = LikeEvent(userId, itemId)
         checkSuccessfulEventAdd(event)
+    }
+
+    @Test
+    fun testAddTrueTestLikeEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = LikeEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestLikeEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = LikeEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -362,12 +472,31 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *           CartaddEvent         *
+     **********************************/
     @Test
     fun testAddCartaddEvent() {
         val userId = generateUUID()
         val itemId = generateUUID()
         val event: Event = CartaddEvent(userId, itemId)
         checkSuccessfulEventAdd(event)
+    }
+
+    @Test
+    fun testAddTrueTestCartaddEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = CartaddEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestCartaddEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val event: Event = CartaddEvent(userId, itemId)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -409,6 +538,9 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *            RateEvent           *
+     **********************************/
     @Test
     fun testAddRateEvent() {
         val userId = generateUUID()
@@ -416,6 +548,24 @@ class ZaiClientKotlinTest {
         val rating = generateRandomDouble(0, 5)
         val event: Event = RateEvent(userId, itemId, rating)
         checkSuccessfulEventAdd(event)
+    }
+
+    @Test
+    fun testAddTrueTestRateEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val rating = generateRandomDouble(0, 5)
+        val event: Event = RateEvent(userId, itemId, rating)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestRateEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val rating = generateRandomDouble(0, 5)
+        val event: Event = RateEvent(userId, itemId, rating)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -460,6 +610,9 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *          PurchaseEvent         *
+     **********************************/
     @Test
     fun testAddPurchaseEvent() {
         val userId = generateUUID()
@@ -467,6 +620,24 @@ class ZaiClientKotlinTest {
         val price = generateRandomInteger(10000, 100000)
         val event: Event = PurchaseEvent(userId, itemId, price)
         checkSuccessfulEventAdd(event)
+    }
+
+    @Test
+    fun testAddTrueTestPurchaseEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val price = generateRandomInteger(10000, 100000)
+        val event: Event = PurchaseEvent(userId, itemId, price)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestPurchaseEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val price = generateRandomInteger(10000, 100000)
+        val event: Event = PurchaseEvent(userId, itemId, price)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -511,6 +682,25 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *           SearchEvent          *
+     **********************************/
+    @Test
+    fun testAddTrueTestSearchEvent() {
+        val userId = generateUUID()
+        val searchQuery = generateSearchQuery()
+        val event: Event = SearchEvent(userId, searchQuery)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestSearchEvent() {
+        val userId = generateUUID()
+        val searchQuery = generateSearchQuery()
+        val event: Event = SearchEvent(userId, searchQuery)
+        checkSuccessfulEventAdd(event, false)
+    }
+
     @Test
     fun testAddSearchEventManualTime() {
         val userId = generateUUID()
@@ -550,6 +740,9 @@ class ZaiClientKotlinTest {
         }
     }
 
+    /**********************************
+     *           CustomEvent          *
+     **********************************/
     @Test
     fun testAddCustomEvent() {
         val userId = generateUUID()
@@ -558,6 +751,26 @@ class ZaiClientKotlinTest {
         val eventValue = "customEventValue"
         val event: Event = CustomEvent(userId, itemId, eventType, eventValue)
         checkSuccessfulEventAdd(event)
+    }
+
+    @Test
+    fun testAddTrueTestCustomEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val eventType = "customEventType"
+        val eventValue = "customEventValue"
+        val event: Event = CustomEvent(userId, itemId, eventType, eventValue)
+        checkSuccessfulEventAdd(event, true)
+    }
+
+    @Test
+    fun testAddFalseTestCustomEvent() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val eventType = "customEventType"
+        val eventValue = "customEventValue"
+        val event: Event = CustomEvent(userId, itemId, eventType, eventValue)
+        checkSuccessfulEventAdd(event, false)
     }
 
     @Test
@@ -681,6 +894,21 @@ class ZaiClientKotlinTest {
         Assert.fail()
     }
 
+    @Test
+    fun testNegativeTimeToLive() {
+        val userId = generateUUID()
+        val itemId = generateUUID()
+        val eventType = generateUUID()
+        val eventValue = ""
+        try {
+            val event: Event = CustomEvent(userId, itemId, eventType, eventValue)
+            event.timeToLive = -defaultDataExpirationSeconds
+        } catch (e: InvalidParameterException) {
+            return
+        }
+        Assert.fail()
+    }
+
     companion object {
         private const val clientId = "test"
         private const val clientSecret =
@@ -691,6 +919,8 @@ class ZaiClientKotlinTest {
         private const val eventTableItemIdKey = "item_id"
         private const val eventTableEventTypeKey = "event_type"
         private const val eventTableEventValueKey = "event_value"
+        private const val eventTableExpirationTimeKey = "expiration_time"
+        private const val defaultDataExpirationSeconds = 60 * 60 * 24 * 365
         private val region = Region.AP_NORTHEAST_2
     }
 }


### PR DESCRIPTION
* `updateEventLog`, `deleteEventLog` 함수를 삭제하고 관련 Test code 또한 삭제하였습니다.

* `addEventLog` 함수에 `isTest` parameter를 추가하여 `isTest`가 true로 들어오는 경우에는 collector api request body에 time_to_live를 60 * 60 * 24 (24시간)으로 설정하여 POST 요청을 보내도록 하였습니다.

* `isTest` parameter관련 사용 예시는 아래와 같습니다.
```java
zaiClient.addEventLog(productDetailView, true);
```

* `isTest` 관련 unit 테스트 코드를 추가했습니다.