### PR TITLE
[hotfix] User Recommendation should receive null user

### DIFF
--- a/src/main/java/org/zaikorea/zaiclient/request/recommendations/GetUserRecommendation.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/recommendations/GetUserRecommendation.java
@@ -35,7 +35,7 @@ public class GetUserRecommendation extends RecommendationRequest {
         private String options = DEFAULT_OPTIONS;
 
         public Builder(String userId, int limit) {
-            this.userId = Validator.validateString(userId, 1, 500, false, "userId");
+            this.userId = Validator.validateString(userId, 1, 500, true, "userId");
             this.limit = Validator.validateNumber(limit, 0, 10000, false, "limit");
         }
 

--- a/src/main/java/org/zaikorea/zaiclient/utils/Validator.java
+++ b/src/main/java/org/zaikorea/zaiclient/utils/Validator.java
@@ -11,6 +11,12 @@ public class Validator {
             return null;
         }
 
+        if (!nullable && value == null) {
+            throw new IllegalArgumentException(
+                    String.format("The value of %s must not be null", varName)
+            );
+        }
+
         int length = value.length();
 
         if ((length < min) || (length > max)) {
@@ -27,6 +33,12 @@ public class Validator {
             return null;
         }
 
+        if (!nullable && value == null) {
+            throw new IllegalArgumentException(
+                    String.format("The value of %s must not be null", varName)
+            );
+        }
+
         int length = value.length();
 
         if (length < min) {
@@ -41,6 +53,12 @@ public class Validator {
     public static List<String> validateStringList(List<String> value, int listMin, int listMax, boolean nullable, String varName) {
         if (nullable && value == null) {
             return null;
+        }
+
+        if (!nullable && value == null) {
+            throw new IllegalArgumentException(
+                    String.format("The value of %s must not be null", varName)
+            );
         }
 
         int length = value.size();

--- a/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetUserRecommendationTest.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetUserRecommendationTest.java
@@ -271,6 +271,29 @@ public class ZaiClientGetUserRecommendationTest {
     }
 
     @Test
+    public void testGetUserRecommendation_3() { // With null user (unregistered user)
+        Metadata metadata;
+        String userId = null;
+        int limit = generateRandomInteger(1, 10);
+        int offset = generateRandomInteger(20, 40);
+
+        RecommendationRequest recommendation = new GetUserRecommendation.Builder(userId, limit)
+                .offset(offset)
+                .build();
+
+        try {
+            metadata = new Metadata();
+            metadata.userId = userId;
+            metadata.limit = limit;
+            metadata.offset = offset;
+            checkSuccessfulGetUserRecommendation(recommendation, userId, metadata);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+    }
+
+    @Test
     public void testGetUserRecommendation_2() {
         Metadata metadata;
         String userId = generateUUID();
@@ -292,6 +315,5 @@ public class ZaiClientGetUserRecommendationTest {
             fail();
         }
     }
-
 
 }


### PR DESCRIPTION
User Recommendation에서 비로그인 유저에 대한 추천을 제공할 때 String(4) "null" 이 아니라 null을 받을 수 있어야 함

