### PR TITLE
[feat] Add url, ref, rec_id, event_props, user_props to Event Requests & rec_id to Recommendation Response

### DIFF
--- a/src/main/java/org/zaikorea/zaiclient/ZaiAPI.java
+++ b/src/main/java/org/zaikorea/zaiclient/ZaiAPI.java
@@ -3,10 +3,8 @@ package org.zaikorea.zaiclient;
 import java.util.List;
 
 import org.zaikorea.zaiclient.configs.Config;
-// import org.zaikorea.zaiclient.request.Event;
 import org.zaikorea.zaiclient.request.events.Event;
 import org.zaikorea.zaiclient.request.recommendations.RecommendationQuery;
-// import org.zaikorea.zaiclient.request.RecommendationRequest;
 import org.zaikorea.zaiclient.request.items.Item;
 import org.zaikorea.zaiclient.response.EventLoggerResponse;
 import org.zaikorea.zaiclient.response.ItemResponse;
@@ -19,34 +17,27 @@ public interface ZaiAPI {
 
     @POST(Config.itemsApiPath)
     Call<ItemResponse> addItem(
-        @Body List<Item> items
-    );
+            @Body List<Item> items);
 
     @PUT(Config.itemsApiPath)
     Call<ItemResponse> updateItem(
-        @Body List<Item> items
-    );
+            @Body List<Item> items);
 
     @DELETE(Config.itemsApiPath)
     Call<ItemResponse> deleteItem(
-        @Query("id") List<String> ids
-    );
-
+            @Query("id") List<String> ids);
 
     @POST(Config.eventsApiPath)
     Call<EventLoggerResponse> addEventLog(
-        @Body Event event
-    );
+            @Body Event event);
 
     @POST(Config.eventsApiPath)
     Call<EventLoggerResponse> addEventLog(
-        @Body List<Event> event
-    );
+            @Body List<Event> event);
 
     @POST
     Call<RecommendationResponse> getRecommendations(
-        @Url String url,
-        @Body RecommendationQuery recQuery
-    );
+            @Url String url,
+            @Body RecommendationQuery recQuery);
 
 }

--- a/src/main/java/org/zaikorea/zaiclient/ZaiClient.java
+++ b/src/main/java/org/zaikorea/zaiclient/ZaiClient.java
@@ -16,7 +16,6 @@ import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 import org.zaikorea.zaiclient.configs.Config;
-import org.zaikorea.zaiclient.exceptions.EmptyBatchException;
 import org.zaikorea.zaiclient.exceptions.ZaiClientException;
 import org.zaikorea.zaiclient.request.events.Event;
 import org.zaikorea.zaiclient.request.events.EventRequest;

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddCartaddEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddCartaddEvent.java
@@ -1,5 +1,8 @@
 package org.zaikorea.zaiclient.request.events;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.zaikorea.zaiclient.utils.Utils;
 
 public class AddCartaddEvent extends EventRequest {
@@ -8,21 +11,31 @@ public class AddCartaddEvent extends EventRequest {
 
     public AddCartaddEvent(Builder builder) {
         this.events.add(new Event()
-            .setUserId(builder.userId)
-            .setItemId(builder.itemId)
-            .setTimestamp(Utils.getCurrentUnixTimestamp())
-            .setEventType(DEFAULT_EVENT_TYPE)
-            .setEventValue(DEFAULT_EVENT_VALUE)
-            .setIsZaiRecommendation(builder.isZaiRecommendation)
-            .setFrom(builder.from)
-        );
+                .setUserId(builder.userId)
+                .setItemId(builder.itemId)
+                .setTimestamp(Utils.getCurrentUnixTimestamp())
+                .setEventType(DEFAULT_EVENT_TYPE)
+                .setEventValue(DEFAULT_EVENT_VALUE)
+                .setIsZaiRecommendation(builder.isZaiRecommendation)
+                .setFrom(builder.from)
+                .setUrl(builder.url)
+                .setRef(builder.ref)
+                .setRecommendationId(builder.recommendationId)
+                .setEventProperties(builder.eventProperties)
+                .setUserProperties(builder.userProperties));
+
     }
 
     public static class Builder {
         private final String userId;
         private final String itemId;
         private boolean isZaiRecommendation = false;
-        private String from;
+        private String from = null;
+        private String url = null;
+        private String ref = null;
+        private String recommendationId = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId, String itemId) {
             this.userId = userId;
@@ -37,6 +50,36 @@ public class AddCartaddEvent extends EventRequest {
 
         public Builder isZaiRecommendation(boolean isZaiRec) {
             this.isZaiRecommendation = isZaiRec;
+
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder recommendationId(String recommendationId) {
+            this.recommendationId = recommendationId;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
 
             return this;
         }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddCustomEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddCustomEvent.java
@@ -1,7 +1,9 @@
 package org.zaikorea.zaiclient.request.events;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.zaikorea.zaiclient.configs.Config;
 import org.zaikorea.zaiclient.exceptions.EmptyBatchException;
@@ -19,15 +21,20 @@ public class AddCustomEvent extends EventRequest {
 
         for (int i = 0; i < builder.itemIds.size(); i++) {
             this.events.add(new Event()
-                .setUserId(builder.userId)
-                .setItemId(builder.itemIds.get(i))
-                .setTimestamp(timestamp + Config.epsilon * i)
-                .setEventType(builder.eventType)
-                .setEventValue(builder.eventValues.get(i))
-                .setTimeToLive(builder.timeToLive.get(i))
-                .setIsZaiRecommendation(builder.isZaiRecommendation.get(i))
-                .setFrom(builder.from.get(i))
-            );
+                    .setUserId(builder.userId)
+                    .setItemId(builder.itemIds.get(i))
+                    .setTimestamp(timestamp + Config.epsilon * i)
+                    .setEventType(builder.eventType)
+                    .setEventValue(builder.eventValues.get(i))
+                    .setTimeToLive(builder.timeToLive.get(i))
+                    .setIsZaiRecommendation(builder.isZaiRecommendation.get(i))
+                    .setFrom(builder.from.get(i))
+                    .setUrl(builder.url)
+                    .setRef(builder.ref)
+                    .setRecommendationId(builder.recommendationId)
+                    .setEventProperties(builder.eventProperties)
+                    .setUserProperties(builder.userProperties));
+
         }
     }
 
@@ -39,6 +46,11 @@ public class AddCustomEvent extends EventRequest {
         private List<Boolean> isZaiRecommendation = new ArrayList<>();
         private List<String> from = new ArrayList<>();
         private List<Integer> timeToLive = new ArrayList<>();
+        private String url = null;
+        private String ref = null;
+        private String recommendationId = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId, String eventType) {
             this.userId = userId;
@@ -94,6 +106,36 @@ public class AddCustomEvent extends EventRequest {
             this.eventValues.remove(idx);
             this.isZaiRecommendation.remove(idx);
             this.from.remove(idx);
+
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder recommendationId(String recommendationId) {
+            this.recommendationId = recommendationId;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
 
             return this;
         }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddLikeEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddLikeEvent.java
@@ -1,5 +1,8 @@
 package org.zaikorea.zaiclient.request.events;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.zaikorea.zaiclient.utils.Utils;
 
 public class AddLikeEvent extends EventRequest {
@@ -8,21 +11,30 @@ public class AddLikeEvent extends EventRequest {
 
     public AddLikeEvent(Builder builder) {
         this.events.add(new Event()
-            .setUserId(builder.userId)
-            .setItemId(builder.itemId)
-            .setTimestamp(Utils.getCurrentUnixTimestamp())
-            .setEventType(DEFAULT_EVENT_TYPE)
-            .setEventValue(DEFAULT_EVENT_VALUE)
-            .setIsZaiRecommendation(builder.isZaiRecommendation)
-            .setFrom(builder.from)
-        );
+                .setUserId(builder.userId)
+                .setItemId(builder.itemId)
+                .setTimestamp(Utils.getCurrentUnixTimestamp())
+                .setEventType(DEFAULT_EVENT_TYPE)
+                .setEventValue(DEFAULT_EVENT_VALUE)
+                .setIsZaiRecommendation(builder.isZaiRecommendation)
+                .setFrom(builder.from)
+                .setUrl(builder.url)
+                .setRef(builder.ref)
+                .setRecommendationId(builder.recommendationId)
+                .setEventProperties(builder.eventProperties)
+                .setUserProperties(builder.userProperties));
     }
 
     public static class Builder {
         private final String userId;
         private final String itemId;
         private boolean isZaiRecommendation = false;
-        private String from;
+        private String from = null;
+        private String url = null;
+        private String ref = null;
+        private String recommendationId = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId, String itemId) {
             this.userId = userId;
@@ -37,6 +49,36 @@ public class AddLikeEvent extends EventRequest {
 
         public Builder isZaiRecommendation(boolean isZaiRec) {
             this.isZaiRecommendation = isZaiRec;
+
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder recommendationId(String recommendationId) {
+            this.recommendationId = recommendationId;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
 
             return this;
         }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddPageViewEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddPageViewEvent.java
@@ -1,5 +1,8 @@
 package org.zaikorea.zaiclient.request.events;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.zaikorea.zaiclient.utils.Utils;
 
 public class AddPageViewEvent extends EventRequest {
@@ -8,14 +11,17 @@ public class AddPageViewEvent extends EventRequest {
 
     public AddPageViewEvent(Builder builder) {
         this.events.add(new Event()
-            .setUserId(builder.userId)
-            .setItemId(DEFAULT_ITEM_ID)
-            .setTimestamp(Utils.getCurrentUnixTimestamp())
-            .setEventType(DEFAULT_EVENT_TYPE)
-            .setEventValue(builder.pageType)
-            .setIsZaiRecommendation(builder.isZaiRecommendation)
-            .setFrom(builder.from)
-        );
+                .setUserId(builder.userId)
+                .setItemId(DEFAULT_ITEM_ID)
+                .setTimestamp(Utils.getCurrentUnixTimestamp())
+                .setEventType(DEFAULT_EVENT_TYPE)
+                .setEventValue(builder.pageType)
+                .setIsZaiRecommendation(builder.isZaiRecommendation)
+                .setFrom(builder.from)
+                .setUrl(builder.url)
+                .setRef(builder.ref)
+                .setEventProperties(builder.eventProperties)
+                .setUserProperties(builder.userProperties));
     }
 
     public static class Builder {
@@ -23,6 +29,10 @@ public class AddPageViewEvent extends EventRequest {
         private final String pageType;
         private boolean isZaiRecommendation = false;
         private String from = null;
+        private String url = null;
+        private String ref = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId, String pageType) {
             this.userId = userId;
@@ -37,6 +47,30 @@ public class AddPageViewEvent extends EventRequest {
 
         public Builder from(String from) {
             this.from = from;
+
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
 
             return this;
         }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddProductDetailViewEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddProductDetailViewEvent.java
@@ -1,5 +1,8 @@
 package org.zaikorea.zaiclient.request.events;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.zaikorea.zaiclient.utils.Utils;
 
 public class AddProductDetailViewEvent extends EventRequest {
@@ -8,15 +11,19 @@ public class AddProductDetailViewEvent extends EventRequest {
 
     public AddProductDetailViewEvent(Builder builder) {
         this.events.add(new Event()
-            .setUserId(builder.userId)
-            .setItemId(builder.itemId)
-            .setTimestamp(builder.timestamp)
-            .setEventType(DEFAULT_EVENT_TYPE)
-            .setEventValue(DEFAULT_EVENT_VALUE)
-            .setTimeToLive(builder.timeToLive)
-            .setIsZaiRecommendation(builder.isZaiRecommendation)
-            .setFrom(builder.from)
-        );
+                .setUserId(builder.userId)
+                .setItemId(builder.itemId)
+                .setTimestamp(builder.timestamp)
+                .setEventType(DEFAULT_EVENT_TYPE)
+                .setEventValue(DEFAULT_EVENT_VALUE)
+                .setTimeToLive(builder.timeToLive)
+                .setIsZaiRecommendation(builder.isZaiRecommendation)
+                .setFrom(builder.from)
+                .setUrl(builder.url)
+                .setRef(builder.ref)
+                .setRecommendationId(builder.recommendationId)
+                .setEventProperties(builder.eventProperties)
+                .setUserProperties(builder.userProperties));
     }
 
     public static class Builder {
@@ -26,6 +33,11 @@ public class AddProductDetailViewEvent extends EventRequest {
         private String from = null;
         private Integer timeToLive = null;
         private boolean isZaiRecommendation = false;
+        private String url = null;
+        private String ref = null;
+        private String recommendationId = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId, String itemId) {
             this.userId = userId;
@@ -49,6 +61,36 @@ public class AddProductDetailViewEvent extends EventRequest {
 
         public Builder from(String from) {
             this.from = from;
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder recommendationId(String recommendationId) {
+            this.recommendationId = recommendationId;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
+
             return this;
         }
 

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddPurchaseEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddPurchaseEvent.java
@@ -1,7 +1,9 @@
 package org.zaikorea.zaiclient.request.events;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.zaikorea.zaiclient.configs.Config;
 import org.zaikorea.zaiclient.exceptions.EmptyBatchException;
@@ -19,16 +21,20 @@ public class AddPurchaseEvent extends EventRequest {
         }
 
         for (int i = 0; i < builder.itemIds.size(); i++) {
-            this.events.add(new Event() // TODO: Creating new Event in a loop is not a good idea. Should be done in Builder methods.
-                .setUserId(builder.userId)
-                .setItemId(builder.itemIds.get(i))
-                .setTimestamp(timestamp + Config.epsilon * i)
-                .setEventType(DEFAULT_EVENT_TYPE)
-                .setEventValue(builder.eventValues.get(i))
-                .setTimeToLive(builder.timeToLive.get(i))
-                .setIsZaiRecommendation(builder.isZaiRecommendation.get(i))
-                .setFrom(builder.from.get(i))
-            );
+            this.events.add(new Event() // TODO: Creating new Event in a loop is not a good idea. Should be done in
+                                        // Builder methods.
+                    .setUserId(builder.userId)
+                    .setItemId(builder.itemIds.get(i))
+                    .setTimestamp(timestamp + Config.epsilon * i)
+                    .setEventType(DEFAULT_EVENT_TYPE)
+                    .setEventValue(builder.eventValues.get(i))
+                    .setTimeToLive(builder.timeToLive.get(i))
+                    .setIsZaiRecommendation(builder.isZaiRecommendation.get(i))
+                    .setFrom(builder.from.get(i))
+                    .setUrl(builder.url)
+                    .setRef(builder.ref)
+                    .setEventProperties(builder.eventProperties)
+                    .setUserProperties(builder.userProperties));
         }
     }
 
@@ -39,6 +45,10 @@ public class AddPurchaseEvent extends EventRequest {
         private List<Boolean> isZaiRecommendation = new ArrayList<>();
         private List<String> from = new ArrayList<>();
         private List<Integer> timeToLive = new ArrayList<>();
+        private String url = null;
+        private String ref = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId) {
             this.userId = userId;
@@ -53,7 +63,8 @@ public class AddPurchaseEvent extends EventRequest {
             return this;
         }
 
-        // BackLog: This might need an interface to receive float number pricing with currency (USD, KRW, etc.)
+        // BackLog: This might need an interface to receive float number pricing with
+        // currency (USD, KRW, etc.)
 
         public Builder addPurchase(String itemId, int price, String from) {
             this.itemIds.add(itemId);
@@ -93,6 +104,30 @@ public class AddPurchaseEvent extends EventRequest {
             this.eventValues.remove(idx);
             this.isZaiRecommendation.remove(idx);
             this.from.remove(idx);
+
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
 
             return this;
         }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddRateEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddRateEvent.java
@@ -1,5 +1,8 @@
 package org.zaikorea.zaiclient.request.events;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.zaikorea.zaiclient.utils.Utils;
 
 public class AddRateEvent extends EventRequest {
@@ -7,14 +10,17 @@ public class AddRateEvent extends EventRequest {
 
     public AddRateEvent(Builder builder) {
         this.events.add(new Event()
-            .setUserId(builder.userId)
-            .setItemId(builder.itemId)
-            .setTimestamp(Utils.getCurrentUnixTimestamp())
-            .setEventType(DEFAULT_EVENT_TYPE)
-            .setEventValue(builder.eventValue)
-            .setIsZaiRecommendation(builder.isZaiRecommendation)
-            .setFrom(builder.from)
-        );
+                .setUserId(builder.userId)
+                .setItemId(builder.itemId)
+                .setTimestamp(Utils.getCurrentUnixTimestamp())
+                .setEventType(DEFAULT_EVENT_TYPE)
+                .setEventValue(builder.eventValue)
+                .setIsZaiRecommendation(builder.isZaiRecommendation)
+                .setFrom(builder.from)
+                .setUrl(builder.url)
+                .setRef(builder.ref)
+                .setEventProperties(builder.eventProperties)
+                .setUserProperties(builder.userProperties));
     }
 
     public static class Builder {
@@ -22,7 +28,11 @@ public class AddRateEvent extends EventRequest {
         private final String itemId;
         private final String eventValue;
         private boolean isZaiRecommendation = false;
-        private String from;
+        private String from = null;
+        private String url = null;
+        private String ref = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId, String itemId, double rating) {
             this.userId = userId;
@@ -38,6 +48,30 @@ public class AddRateEvent extends EventRequest {
 
         public Builder isZaiRecommendation(boolean isZaiRec) {
             this.isZaiRecommendation = isZaiRec;
+
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
 
             return this;
         }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/AddSearchEvent.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/AddSearchEvent.java
@@ -1,5 +1,8 @@
 package org.zaikorea.zaiclient.request.events;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.zaikorea.zaiclient.utils.Utils;
 
 public class AddSearchEvent extends EventRequest {
@@ -8,19 +11,26 @@ public class AddSearchEvent extends EventRequest {
 
     public AddSearchEvent(Builder builder) {
         this.events.add(new Event()
-            .setUserId(builder.userId)
-            .setItemId(DEFAULT_ITEM_ID)
-            .setTimestamp(Utils.getCurrentUnixTimestamp())
-            .setEventType(DEFAULT_EVENT_TYPE)
-            .setEventValue(builder.eventValue)
-            .setIsZaiRecommendation(builder.isZaiRecommendation)
-        );
+                .setUserId(builder.userId)
+                .setItemId(DEFAULT_ITEM_ID)
+                .setTimestamp(Utils.getCurrentUnixTimestamp())
+                .setEventType(DEFAULT_EVENT_TYPE)
+                .setEventValue(builder.eventValue)
+                .setIsZaiRecommendation(builder.isZaiRecommendation)
+                .setUrl(builder.url)
+                .setRef(builder.ref)
+                .setEventProperties(builder.eventProperties)
+                .setUserProperties(builder.userProperties));
     }
 
     public static class Builder {
         private final String userId;
         private final String eventValue;
         private boolean isZaiRecommendation = false;
+        private String url = null;
+        private String ref = null;
+        private Map<String, ?> eventProperties = new HashMap<>();
+        private Map<String, ?> userProperties = new HashMap<>();
 
         public Builder(String userId, String searchQuery) {
             this.userId = userId;
@@ -29,6 +39,30 @@ public class AddSearchEvent extends EventRequest {
 
         public Builder isZaiRecommendation(boolean isZaiRec) {
             this.isZaiRecommendation = isZaiRec;
+
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+
+            return this;
+        }
+
+        public Builder ref(String ref) {
+            this.ref = ref;
+
+            return this;
+        }
+
+        public Builder eventProperties(Map<String, ?> eventProperties) {
+            this.eventProperties = eventProperties;
+
+            return this;
+        }
+
+        public Builder userProperties(Map<String, ?> userProperties) {
+            this.userProperties = userProperties;
 
             return this;
         }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/Event.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/Event.java
@@ -2,10 +2,11 @@ package org.zaikorea.zaiclient.request.events;
 
 import org.zaikorea.zaiclient.utils.Validator;
 
+import java.util.HashMap;
+import java.util.Map;
 import com.google.gson.annotations.SerializedName;
 
 public class Event {
-
 
     @SerializedName("user_id")
     protected String userId;
@@ -30,6 +31,21 @@ public class Event {
 
     @SerializedName("from")
     protected String from = null;
+
+    @SerializedName("url")
+    protected String url = null;
+
+    @SerializedName("ref")
+    protected String ref = null;
+
+    @SerializedName("recommendation_id")
+    protected String recommendationId = null;
+
+    @SerializedName("event_properties")
+    protected Map<String, ?> eventProperties = new HashMap<>();
+
+    @SerializedName("user_properties")
+    protected Map<String, ?> userProperties = new HashMap<>();
 
     public String getUserId() {
         return userId;
@@ -63,6 +79,26 @@ public class Event {
         return from;
     }
 
+    public String getUrl() {
+        return url;
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public String getRecommendationId() {
+        return recommendationId;
+    }
+
+    public Map<String, ?> getEventProperties() {
+        return eventProperties;
+    }
+
+    public Map<String, ?> getUserProperties() {
+        return userProperties;
+    }
+
     public Event setUserId(String userId) {
         this.userId = Validator.validateString(userId, 1, 500, false, "userId");
 
@@ -82,7 +118,8 @@ public class Event {
     }
 
     public Event setTimestamp(long timestamp) {
-        this.timestamp = Validator.validateNumber(timestamp, (long) 1_648_871_097, (long) 2_147_483_647, false, "timestamp");
+        this.timestamp = Validator.validateNumber(timestamp, (long) 1_648_871_097, (long) 2_147_483_647, false,
+                "timestamp");
 
         return this;
     }
@@ -100,7 +137,7 @@ public class Event {
     }
 
     public Event setEventValue(String eventValue) {
-        this.eventValue = Validator.validateString(eventValue, 0, 500, true, "eventValue");
+        this.eventValue = Validator.validateString(eventValue, 0, 500, false, "eventValue");
 
         return this;
     }
@@ -119,6 +156,36 @@ public class Event {
 
     public Event setTimeToLive(Integer timeToLive) {
         this.timeToLive = Validator.validateNumber(timeToLive, 0, 2_147_483_647, true, "timeToLive");
+
+        return this;
+    }
+
+    public Event setUrl(String url) {
+        this.url = Validator.validateString(url, 0, true, "url");
+
+        return this;
+    }
+
+    public Event setRef(String ref) {
+        this.ref = Validator.validateString(ref, 0, true, "ref");
+
+        return this;
+    }
+
+    public Event setRecommendationId(String recommendationId) {
+        this.recommendationId = Validator.validateString(recommendationId, 0, true, "recommendationId");
+
+        return this;
+    }
+
+    public Event setEventProperties(Map<String, ?> eventProperties) {
+        this.eventProperties = eventProperties;
+
+        return this;
+    }
+
+    public Event setUserProperties(Map<String, ?> userProperties) {
+        this.userProperties = userProperties;
 
         return this;
     }

--- a/src/main/java/org/zaikorea/zaiclient/request/events/EventRequest.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/events/EventRequest.java
@@ -7,25 +7,25 @@ import org.zaikorea.zaiclient.configs.Config;
 import org.zaikorea.zaiclient.request.IRequest;
 
 public class EventRequest implements IRequest<List<Event>> {
-        protected List<Event> events;
+    protected List<Event> events;
 
-        public EventRequest() {
-            events = new LinkedList<Event>();
-            // Do nothing
-        }
+    public EventRequest() {
+        events = new LinkedList<Event>();
+        // Do nothing
+    }
 
-        public void setEvents(List<Event> events) {
-            this.events = events;
-        }
+    public void setEvents(List<Event> events) {
+        this.events = events;
+    }
 
-        public void setEventsToExpire() {
-            for (Event event : events) {
-                event.setTimeToLive(Config.testEventTimeToLive);
-            }
+    public void setEventsToExpire() {
+        for (Event event : events) {
+            event.setTimeToLive(Config.testEventTimeToLive);
         }
+    }
 
-        @Override
-        public List<Event> getPayload() {
-            return events;
-        }
+    @Override
+    public List<Event> getPayload() {
+        return events;
+    }
 }

--- a/src/main/java/org/zaikorea/zaiclient/response/RecommendationResponse.java
+++ b/src/main/java/org/zaikorea/zaiclient/response/RecommendationResponse.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 
 public class RecommendationResponse {
-    
+
     @SerializedName("items")
     private List<String> items;
 
@@ -21,21 +21,36 @@ public class RecommendationResponse {
     @SerializedName("metadata")
     private String metadata;
 
-    public List<String> getItems() { return items; }
+    @SerializedName("recommendation_id")
+    private String recommendationId;
 
-    public int getCount() { return count; }
+    public List<String> getItems() {
+        return items;
+    }
 
-    public double getTimestamp() { return this.timestamp; }
+    public int getCount() {
+        return count;
+    }
+
+    public double getTimestamp() {
+        return this.timestamp;
+    }
 
     public String getMetadata() {
         Gson gson = new Gson();
         try {
             Map<String, Object> json = gson.fromJson(metadata, Map.class);
         } catch (JsonSyntaxException e) {
-            System.out.println(String.format("WARNING: Failed to parse the metadata to object, returning an empty object. metadata: %s", metadata));
+            System.out.println(String.format(
+                    "WARNING: Failed to parse the metadata to object, returning an empty object. metadata: %s",
+                    metadata));
             metadata = "{}";
         }
 
         return metadata;
+    }
+
+    public String getRecommendationId() {
+        return recommendationId;
     }
 }

--- a/src/test/java/org/zaikorea/zaiclienttest/Metadata.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/Metadata.java
@@ -6,60 +6,58 @@ import java.util.Map;
 import java.util.HashMap;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.google.gson.annotations.SerializedName;
 
 public class Metadata {
 
-        @JsonAlias("user_id")
-        public String userId;
+    @JsonAlias("user_id")
+    public String userId;
 
-        @JsonAlias("item_id")
-        public String itemId;
+    @JsonAlias("item_id")
+    public String itemId;
 
-        @JsonAlias("item_ids")
-        public List<String> itemIds;
+    @JsonAlias("item_ids")
+    public List<String> itemIds;
 
-        @JsonAlias("limit")
-        public Integer limit;
+    @JsonAlias("limit")
+    public Integer limit;
 
-        @JsonAlias("offset")
-        public Integer offset;
+    @JsonAlias("offset")
+    public Integer offset;
 
-        @JsonAlias("options")
-        public Map<String, ?> options;
+    @JsonAlias("options")
+    public Map<String, ?> options;
 
-        @JsonAlias("call_type")
-        public String callType;
+    @JsonAlias("call_type")
+    public String callType;
 
-        @JsonAlias("recommendation_type")
-        public String recommendationType;
+    @JsonAlias("recommendation_type")
+    public String recommendationType;
 
-        public Metadata() {
-            this.offset = 0;
-            this.options = new HashMap<>();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-
-            try {
-                for (Field field: obj.getClass().getFields()) {
-                    if (field.get(obj) != null && field.get(obj).equals(field.get(this)))
-                        continue;
-                    else {
-                        if (field.get(obj) == null && field.get(this) == null)
-                            continue;
-                        else
-                            return false;
-                    }
-                }
-            } catch (IllegalArgumentException | IllegalAccessException e) {
-                System.out.println(e.getMessage());
-
-                return false;
-            }
-
-            return true;
-        }
+    public Metadata() {
+        this.offset = 0;
+        this.options = new HashMap<>();
     }
 
+    @Override
+    public boolean equals(Object obj) {
+
+        try {
+            for (Field field : obj.getClass().getFields()) {
+                if (field.get(obj) != null && field.get(obj).equals(field.get(this)))
+                    continue;
+                else {
+                    if (field.get(obj) == null && field.get(this) == null)
+                        continue;
+                    else
+                        return false;
+                }
+            }
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            System.out.println(e.getMessage());
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/org/zaikorea/zaiclienttest/TestUtils.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/TestUtils.java
@@ -3,6 +3,8 @@ package org.zaikorea.zaiclienttest;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
 public class TestUtils {
 
     public static String generateUUID() {
@@ -12,5 +14,4 @@ public class TestUtils {
     public static int generateRandomInteger(int min, int max) {
         return ThreadLocalRandom.current().nextInt(min, max + 1);
     }
-
 }

--- a/src/test/java/org/zaikorea/zaiclienttest/TestUtils.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/TestUtils.java
@@ -1,5 +1,7 @@
 package org.zaikorea.zaiclienttest;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -13,5 +15,43 @@ public class TestUtils {
 
     public static int generateRandomInteger(int min, int max) {
         return ThreadLocalRandom.current().nextInt(min, max + 1);
+    }
+
+    public static Map<String, Object> ddbMapToJavaMap(Map<String, AttributeValue> itemMap) {
+        Map<String, Object> javaMap = new HashMap<>();
+
+        for (Map.Entry<String, AttributeValue> entry : itemMap.entrySet()) {
+            String key = entry.getKey();
+            AttributeValue attributeValue = entry.getValue();
+
+            // AttributeValue의 데이터 타입에 따라 적절한 Java 객체로 변환
+            Object javaValue = toJavaObject(attributeValue);
+
+            javaMap.put(key, javaValue);
+        }
+
+        return javaMap;
+    }
+
+    public static Object toJavaObject(AttributeValue attributeValue) {
+        if (attributeValue.s() != null) {
+            return attributeValue.s();
+        } else if (attributeValue.n() != null) {
+            return attributeValue.n();
+        } else if (attributeValue.bool() != null) {
+            return attributeValue.bool();
+        } else if (attributeValue.nul() != null) {
+            return null;
+        } else if (attributeValue.hasM()) {
+            // 중첩된 Map의 경우 재귀적으로 변환
+            return ddbMapToJavaMap(attributeValue.m());
+        } else if (attributeValue.hasL()) {
+            return attributeValue.l().stream()
+                    .map(TestUtils::toJavaObject)
+                    .collect(java.util.stream.Collectors.toList());
+        } else {
+            // 그 외의 경우는 null 또는 다른 형태의 데이터일 수 있음
+            return null;
+        }
     }
 }

--- a/src/test/java/org/zaikorea/zaiclienttest/ZaiCilentEventTest.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/ZaiCilentEventTest.java
@@ -118,43 +118,6 @@ public class ZaiCilentEventTest {
         return sb.toString();
     }
 
-    private static Map<String, Object> ddbMapToJavaMap(Map<String, AttributeValue> itemMap) {
-        Map<String, Object> javaMap = new HashMap<>();
-
-        for (Map.Entry<String, AttributeValue> entry : itemMap.entrySet()) {
-            String key = entry.getKey();
-            AttributeValue attributeValue = entry.getValue();
-
-            // AttributeValue의 데이터 타입에 따라 적절한 Java 객체로 변환
-            Object javaValue = toJavaObject(attributeValue);
-
-            javaMap.put(key, javaValue);
-        }
-
-        return javaMap;
-    }
-
-    private static Object toJavaObject(AttributeValue attributeValue) {
-        if (attributeValue.s() != null) {
-            return attributeValue.s();
-        } else if (attributeValue.n() != null) {
-            return attributeValue.n();
-        } else if (attributeValue.bool() != null) {
-            return attributeValue.bool();
-        } else if (attributeValue.m() != null) {
-            // 중첩된 Map의 경우 재귀적으로 변환
-            return ddbMapToJavaMap(attributeValue.m());
-        } else if (attributeValue.l() != null) {
-            // 리스트의 경우 재귀적으로 변환
-            return attributeValue.l().stream()
-                    .map(ZaiCilentEventTest::toJavaObject)
-                    .collect(java.util.stream.Collectors.toList());
-        } else {
-            // 그 외의 경우는 null 또는 다른 형태의 데이터일 수 있음
-            return null;
-        }
-    }
-
     private Map<String, String> getEventLog(String partitionValue) {
 
         String partitionAlias = "#pk";
@@ -185,7 +148,7 @@ public class ZaiCilentEventTest {
                 for (String key : returnedItem.keySet()) {
                     // Convert AttributeValue to Java Object
                     AttributeValue attributeValue = returnedItem.get(key);
-                    String val = toJavaObject(attributeValue).toString();
+                    String val = Objects.toString(TestUtils.toJavaObject(attributeValue));
                     item.put(key, val);
                 }
                 return item;
@@ -217,7 +180,7 @@ public class ZaiCilentEventTest {
                 for (String key : returnedItem.keySet()) {
                     // Convert AttributeValue to Java Object
                     AttributeValue attributeValue = returnedItem.get(key);
-                    String val = toJavaObject(attributeValue).toString();
+                    String val = Objects.toString(TestUtils.toJavaObject(attributeValue));
                     item.put(key, val);
                 }
                 return item;

--- a/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetUserRecommendationTest.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetUserRecommendationTest.java
@@ -3,6 +3,7 @@ package org.zaikorea.zaiclienttest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -11,6 +12,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -79,7 +81,7 @@ public class ZaiClientGetUserRecommendationTest {
         public boolean equals(Object obj) {
 
             try {
-                for (Field field: obj.getClass().getFields()) {
+                for (Field field : obj.getClass().getFields()) {
                     if (field.get(obj) != null && field.get(obj).equals(field.get(this)))
                         continue;
                     else {
@@ -105,7 +107,14 @@ public class ZaiClientGetUserRecommendationTest {
     private static final String recLogTableName = "rec_log_test";
     private static final String recLogTablePartitionKey = "user_id";
     private static final String recLogTableSortKey = "timestamp";
-    private static final String recLogRecommendations = "recommendations";
+    private static final String recLogRecommendationTypeKey = "recommendation_type";
+    private static final String recLogOffsetKey = "offset";
+    private static final String recLogItemIdKey = "item_id";
+    private static final String recLogRecommendationIdKey = "recommendation_id";
+    private static final String recLogRecommendationsKey = "recommendations";
+    private static final String recLogUserIdKey = "user_id";
+    private static final String recLogLimitKey = "limit";
+    private static final String recLogItemIdsKey = "item_ids";
 
     private ZaiClient testClient;
 
@@ -148,8 +157,10 @@ public class ZaiClientGetUserRecommendationTest {
             Map<String, String> item = new HashMap<>();
             if (returnedItem != null) {
                 for (String key : returnedItem.keySet()) {
-                    String val = returnedItem.get(key).toString();
-                    item.put(key, val.substring(17, val.length() - 1));
+                    // Convert AttributeValue to Java Object
+                    AttributeValue attributeValue = returnedItem.get(key);
+                    String val = Objects.toString(TestUtils.toJavaObject(attributeValue));
+                    item.put(key, val);
                 }
                 return item;
             }
@@ -160,7 +171,6 @@ public class ZaiClientGetUserRecommendationTest {
             return null;
         }
     }
-
 
     private boolean deleteRecLog(String partitionValue) {
 
@@ -186,11 +196,15 @@ public class ZaiClientGetUserRecommendationTest {
         return true;
     }
 
-    private void checkSuccessfulGetUserRecommendation(RecommendationRequest recommendation, String userId, Metadata expectedMetadata) {
+    private void checkSuccessfulGetUserRecommendation(RecommendationRequest recommendation, Metadata expectedMetadata) {
         RecommendationQuery recQuery = recommendation.getPayload();
 
-        int limit = recQuery.getLimit();
+        String recommendationType = recQuery.getRecommendationType();
         int offset = recQuery.getOffset();
+        String userId = recQuery.getUserId();
+        String itemId = recQuery.getItemId();
+        int limit = recQuery.getLimit();
+        List<String> itemIds = recQuery.getItemIds();
         Gson gson = new Gson();
 
         try {
@@ -198,8 +212,9 @@ public class ZaiClientGetUserRecommendationTest {
 
             // Response Testing
             List<String> responseItems = response.getItems();
+            String recommendationId = response.getRecommendationId();
             for (int i = 0; i < limit; i++) {
-                String expectedItem = String.format("ITEM_ID_%d", i+offset);
+                String expectedItem = String.format("ITEM_ID_%d", i + offset);
                 assertEquals(expectedItem, responseItems.get(i));
             }
 
@@ -211,16 +226,20 @@ public class ZaiClientGetUserRecommendationTest {
 
             // Log testing unavailable when userId is null
             if (userId == null)
-                return ;
+                return;
 
             // Check log
             Map<String, String> logItem = getRecLog(userId);
             assertNotNull(logItem);
-            assertNotEquals(logItem.size(), 0);
-            assertEquals(logItem.get(
-                            recLogRecommendations).split(",").length,
-                    response.getItems().size()
-            );
+            assertNotEquals(0, logItem.size());
+            assertEquals(Objects.toString(recommendationType), logItem.get(recLogRecommendationTypeKey));
+            assertEquals(Objects.toString(offset), logItem.get(recLogOffsetKey));
+            assertEquals(Objects.toString(itemId), logItem.get(recLogItemIdKey));
+            assertEquals(Objects.toString(recommendationId), logItem.get(recLogRecommendationIdKey));
+            assertEquals(Objects.toString(responseItems), logItem.get(recLogRecommendationsKey));
+            assertEquals(Objects.toString(userId), logItem.get(recLogUserIdKey));
+            assertEquals(Objects.toString(limit), logItem.get(recLogLimitKey));
+            assertEquals(Objects.toString(itemIds), logItem.get(recLogItemIdsKey));
             assertTrue(deleteRecLog(userId));
 
         } catch (IOException | ZaiClientException e) {
@@ -263,7 +282,7 @@ public class ZaiClientGetUserRecommendationTest {
             metadata.limit = limit;
             metadata.offset = offset;
             metadata.recommendationType = recommendationType;
-            checkSuccessfulGetUserRecommendation(recommendation, userId, metadata);
+            checkSuccessfulGetUserRecommendation(recommendation, metadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());
             fail();
@@ -286,12 +305,11 @@ public class ZaiClientGetUserRecommendationTest {
             metadata.userId = userId;
             metadata.limit = limit;
             metadata.offset = offset;
-            checkSuccessfulGetUserRecommendation(recommendation, userId, metadata);
+            checkSuccessfulGetUserRecommendation(recommendation, metadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());
             fail();
         }
     }
-
 
 }


### PR DESCRIPTION
- 다음의 optional 필드를 Event Request에 추가했습니다.
  - `url`: String
  - `ref`: String
  - `event_properties`: Map<String, ?>
  - `user_properties`: Map<String, ?>

  (Cartadd, PDV, Like, Custom에 대해서는 `recommendation_id`도 추가했습니다.

- `RecommendationResponse`에 `recommendation_id`를 추가했습니다.

- 새로운 필드를 추가함에 따라 Test Code를 수정했습니다.
  - DynamoDB에서 데이터를 읽어올 시 value가 `AttributeValue` 타입인 Map 형태로 읽어오게 되는데, assert 시 이를 적절히 Java Object 형태로 parsing하는 코드를 추가하였습니다.