### PR TITLE
[feat] Change getMetadata return type String -> Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation 'com.github.zaikorea:zaiclient-java:v3.2.0'
+  implementation 'com.github.zaikorea:zaiclient-java:v3.2.1'
 }
 ```
 
@@ -50,7 +50,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation("com.github.zaikorea:zaiclient-java:v3.2.0")
+  implementation("com.github.zaikorea:zaiclient-java:v3.2.1")
 }
 ```
 
@@ -71,6 +71,6 @@ dependencies {
   <dependency>
     <groupId>com.github.zaikorea</groupId>
     <artifactId>zaiclient-java</artifactId>
-    <version>v3.2.0</version>
+    <version>v3.2.1</version>
   </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zaikorea</groupId>
     <artifactId>zaiclient</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
 
     <name>zaiclient</name>
     <url>https://github.com/zaikorea/zaiclient</url>

--- a/src/main/java/org/zaikorea/zaiclient/response/RecommendationResponse.java
+++ b/src/main/java/org/zaikorea/zaiclient/response/RecommendationResponse.java
@@ -1,5 +1,6 @@
 package org.zaikorea.zaiclient.response;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,19 +37,17 @@ public class RecommendationResponse {
         return this.timestamp;
     }
 
-    public String getMetadata() {
+    public Map<String, Object> getMetadata() {
         Gson gson = new Gson();
         try {
-            Map<String, Object> json = gson.fromJson(metadata, Map.class);
+            return gson.fromJson(metadata, Map.class);
         } catch (JsonSyntaxException e) {
             System.out.println(String.format(
                     "WARNING: Failed to parse the metadata to object, returning an empty object. metadata: %s",
                     metadata));
-            metadata = "{}";
+            return new HashMap<>();
         }
-
-        return metadata;
-    }
+    }   
 
     public String getRecommendationId() {
         return recommendationId;

--- a/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetCustomRecommendationTest.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetCustomRecommendationTest.java
@@ -23,8 +23,6 @@ import org.zaikorea.zaiclient.request.recommendations.RecommendationQuery;
 import org.zaikorea.zaiclient.request.recommendations.RecommendationRequest;
 import org.zaikorea.zaiclient.response.RecommendationResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -51,7 +49,6 @@ public class ZaiClientGetCustomRecommendationTest {
 
     private static final String illegalAccessExceptionMessage = "At least one of userId, itemId, or itemIds must be provided.";
     private static final String nullLimitExceptionMessage = "The value of limit must not be null";
-    private static final String unprocessibleEntityExceptionMessage = "Unprocessable Entity";
 
     private ZaiClient testClientToDevEndpoint; // TODO: Figure out to map dev endpoint with environment variable
     private static final Region region = Region.AP_NORTHEAST_2;
@@ -125,7 +122,7 @@ public class ZaiClientGetCustomRecommendationTest {
     }
 
     private void checkSuccessfulGetCustomRecommendation(RecommendationRequest recommendation,
-            Metadata expectedMetadata) {
+            Map<String, Object> expectedMetadata) {
         RecommendationQuery recQuery = recommendation.getPayload();
 
         String recommendationType = recQuery.getRecommendationType();
@@ -134,7 +131,6 @@ public class ZaiClientGetCustomRecommendationTest {
         String itemId = recQuery.getItemId();
         int limit = recQuery.getLimit();
         List<String> itemIds = recQuery.getItemIds();
-        ObjectMapper mapper = new ObjectMapper();
 
         try {
             RecommendationResponse response = testClientToDevEndpoint.sendRequest(recommendation);
@@ -148,9 +144,14 @@ public class ZaiClientGetCustomRecommendationTest {
             }
 
             // Metadata Testing
-            Metadata metadata = mapper.readValue(response.getMetadata(), Metadata.class);
-
-            assertEquals(expectedMetadata, metadata);
+            Map<String, Object> metadata = response.getMetadata();
+            for (String key : expectedMetadata.keySet()) {
+                if (expectedMetadata.get(key) instanceof Integer && metadata.get(key) instanceof Double)
+                    assertEquals(expectedMetadata.get(key), ((Double) metadata.get(key)).intValue());    
+                else
+                    assertEquals(expectedMetadata.get(key), metadata.get(key));    
+            }
+            
             assertEquals(response.getItems().size(), limit);
             assertEquals(response.getCount(), limit);
 
@@ -209,14 +210,12 @@ public class ZaiClientGetCustomRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-
-            expectedMetadata.userId = userId;
-            expectedMetadata.limit = limit;
-            expectedMetadata.offset = offset;
-            expectedMetadata.recommendationType = recommendationType;
-            expectedMetadata.callType = recommendationType;
-
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("offset", offset);
+            expectedMetadata.put("recommendation_type", recommendationType);
+            expectedMetadata.put("call_type", recommendationType);
             checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             fail();
@@ -237,12 +236,11 @@ public class ZaiClientGetCustomRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata(); // call_type and recommendation_type are same for custom
-                                                        // recommendations
-            expectedMetadata.itemId = itemId;
-            expectedMetadata.limit = limit;
-            expectedMetadata.recommendationType = recommendationType;
-            expectedMetadata.callType = recommendationType;
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("item_id", itemId);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("recommendation_type", recommendationType);
+            expectedMetadata.put("call_type", recommendationType);
             checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             fail();
@@ -266,12 +264,11 @@ public class ZaiClientGetCustomRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = itemIds.size();
-            expectedMetadata.recommendationType = recommendationType;
-            expectedMetadata.callType = recommendationType;
-
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", itemIds.size());
+            expectedMetadata.put("recommendation_type", recommendationType);
+            expectedMetadata.put("call_type", recommendationType);
             checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             fail();
@@ -300,14 +297,13 @@ public class ZaiClientGetCustomRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemId = itemId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = limit;
-            expectedMetadata.recommendationType = recommendationType;
-            expectedMetadata.callType = recommendationType;
-
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_id", itemId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("recommendation_type", recommendationType);
+            expectedMetadata.put("call_type", recommendationType);
             checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             fail();
@@ -341,15 +337,14 @@ public class ZaiClientGetCustomRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemId = itemId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = limit;
-            expectedMetadata.recommendationType = recommendationType;
-            expectedMetadata.callType = recommendationType;
-            expectedMetadata.options = options;
-
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_id", itemId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("recommendation_type", recommendationType);
+            expectedMetadata.put("call_type", recommendationType);
+            expectedMetadata.put("options", options);
             checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             fail();
@@ -383,15 +378,13 @@ public class ZaiClientGetCustomRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemId = itemId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = limit;
-            expectedMetadata.recommendationType = recommendationType;
-            expectedMetadata.callType = recommendationType;
-            expectedMetadata.options = options;
-
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_id", itemId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("recommendation_type", recommendationType);
+            expectedMetadata.put("call_type", recommendationType);
             checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             fail();
@@ -421,15 +414,16 @@ public class ZaiClientGetCustomRecommendationTest {
             itemIds.add(TestUtils.generateUUID());
         }
 
+        
+
         try {
             RecommendationRequest recommendation = new GetCustomRecommendation.Builder("homepage-main-recommendations")
-                    .itemIds(itemIds)
-                    .build();
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.offset = 0;
+                .itemIds(itemIds)
+                .build();
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("offset", 0);
             checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
-
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals(nullLimitExceptionMessage, e.getMessage());

--- a/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetRelatedItemsRecommendationTest.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetRelatedItemsRecommendationTest.java
@@ -8,7 +8,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.*;
 
-import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import org.junit.After;
 import org.junit.Before;
@@ -183,7 +182,7 @@ public class ZaiClientGetRelatedItemsRecommendationTest {
     }
 
     private void checkSuccessfulGetRelatedRecommendation(RecommendationRequest recommendation,
-            Metadata expectedMetadata) {
+            Map<String, Object> expectedMetadata) {
         RecommendationQuery recQuery = recommendation.getPayload();
 
         String recommendationType = recQuery.getRecommendationType();
@@ -192,7 +191,6 @@ public class ZaiClientGetRelatedItemsRecommendationTest {
         String itemId = recQuery.getItemId();
         int limit = recQuery.getLimit();
         List<String> itemIds = recQuery.getItemIds();
-        Gson gson = new Gson();
 
         try {
             RecommendationResponse response = testClientToDevEndpoint.sendRequest(recommendation);
@@ -206,8 +204,14 @@ public class ZaiClientGetRelatedItemsRecommendationTest {
             }
 
             // Metadata Testing
-            Metadata metadata = gson.fromJson(response.getMetadata(), Metadata.class);
-            assertEquals(expectedMetadata, metadata);
+            Map<String, Object> metadata = response.getMetadata();
+            for (String key : expectedMetadata.keySet()) {
+                if (expectedMetadata.get(key) instanceof Integer && metadata.get(key) instanceof Double)
+                    assertEquals(expectedMetadata.get(key), ((Double) metadata.get(key)).intValue());    
+                else
+                    assertEquals(expectedMetadata.get(key), metadata.get(key));    
+            }
+
             assertEquals(response.getItems().size(), limit);
             assertEquals(response.getCount(), limit);
 
@@ -248,7 +252,6 @@ public class ZaiClientGetRelatedItemsRecommendationTest {
 
     @Test
     public void testGetRelatedRecommendation_1() {
-        Metadata metadata;
         String itemId = generateUUID();
         int limit = generateRandomInteger(1, 10);
         int offset = generateRandomInteger(20, 40);
@@ -261,13 +264,13 @@ public class ZaiClientGetRelatedItemsRecommendationTest {
                 .build();
 
         try {
-            metadata = new Metadata();
-            metadata.userId = targetUserId;
-            metadata.itemId = itemId;
-            metadata.limit = limit;
-            metadata.offset = offset;
-            metadata.recommendationType = recommendationType;
-            checkSuccessfulGetRelatedRecommendation(recommendation, metadata);
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", targetUserId);
+            expectedMetadata.put("item_id", itemId);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("offset", offset);
+            expectedMetadata.put("recommendation_type", recommendationType);
+            checkSuccessfulGetRelatedRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());
             fail();
@@ -276,7 +279,6 @@ public class ZaiClientGetRelatedItemsRecommendationTest {
 
     @Test
     public void testGetRelatedRecommendation_2() {
-        Metadata metadata;
         String itemId = generateUUID();
         int limit = generateRandomInteger(1, 10);
         int offset = generateRandomInteger(20, 40);
@@ -287,12 +289,12 @@ public class ZaiClientGetRelatedItemsRecommendationTest {
                 .build();
 
         try {
-            metadata = new Metadata();
-            metadata.userId = targetUserId;
-            metadata.itemId = itemId;
-            metadata.limit = limit;
-            metadata.offset = offset;
-            checkSuccessfulGetRelatedRecommendation(recommendation, metadata);
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", targetUserId);
+            expectedMetadata.put("item_id", itemId);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("offset", offset);
+            checkSuccessfulGetRelatedRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             fail();
         }

--- a/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetRerankingRecommendationTest.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetRerankingRecommendationTest.java
@@ -26,7 +26,6 @@ import org.zaikorea.zaiclient.request.recommendations.RecommendationQuery;
 import org.zaikorea.zaiclient.request.recommendations.RecommendationRequest;
 import org.zaikorea.zaiclient.response.RecommendationResponse;
 
-import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
 import software.amazon.awssdk.regions.Region;
@@ -185,7 +184,7 @@ public class ZaiClientGetRerankingRecommendationTest {
     }
 
     private void checkSuccessfulGetRerankingRecommendation(RecommendationRequest recommendation,
-            Metadata expectedMetadata) {
+    Map<String, Object> expectedMetadata) {
         RecommendationQuery recQuery = recommendation.getPayload();
 
         String recommendationType = recQuery.getRecommendationType();
@@ -194,7 +193,6 @@ public class ZaiClientGetRerankingRecommendationTest {
         String itemId = recQuery.getItemId();
         int limit = recQuery.getLimit();
         List<String> itemIds = recQuery.getItemIds();
-        Gson gson = new Gson();
 
         try {
             RecommendationResponse response = testClient.sendRequest(recommendation);
@@ -208,8 +206,13 @@ public class ZaiClientGetRerankingRecommendationTest {
             }
 
             // Metadata Testing
-            Metadata metadata = gson.fromJson(response.getMetadata(), Metadata.class);
-            assertEquals(expectedMetadata, metadata);
+            Map<String, Object> metadata = response.getMetadata();
+            for (String key : expectedMetadata.keySet()) {
+                if (expectedMetadata.get(key) instanceof Integer && metadata.get(key) instanceof Double)
+                    assertEquals(expectedMetadata.get(key), ((Double) metadata.get(key)).intValue());    
+                else
+                    assertEquals(expectedMetadata.get(key), metadata.get(key));    
+            }
             assertEquals(response.getItems().size(), limit);
             assertEquals(response.getCount(), limit);
 
@@ -271,11 +274,11 @@ public class ZaiClientGetRerankingRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = limit;
-            expectedMetadata.offset = offset;
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("offset", offset);
             checkSuccessfulGetRerankingRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());
@@ -299,11 +302,11 @@ public class ZaiClientGetRerankingRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = limit;
-            expectedMetadata.offset = offset;
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("offset", offset);
             checkSuccessfulGetRerankingRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());
@@ -325,10 +328,10 @@ public class ZaiClientGetRerankingRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = limit;
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", limit);
             checkSuccessfulGetRerankingRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());
@@ -348,10 +351,10 @@ public class ZaiClientGetRerankingRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = itemIds.size();
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", itemIds.size());
             checkSuccessfulGetRerankingRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());
@@ -373,11 +376,11 @@ public class ZaiClientGetRerankingRecommendationTest {
                 .build();
 
         try {
-            Metadata expectedMetadata = new Metadata();
-            expectedMetadata.userId = userId;
-            expectedMetadata.itemIds = itemIds;
-            expectedMetadata.limit = itemIds.size();
-            expectedMetadata.recommendationType = recommendationType;
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("user_id", userId);
+            expectedMetadata.put("item_ids", itemIds);
+            expectedMetadata.put("limit", itemIds.size());
+            expectedMetadata.put("recommendation_type", recommendationType);
             checkSuccessfulGetRerankingRecommendation(recommendation, expectedMetadata);
         } catch (Exception e) {
             System.out.println(e.getMessage());

--- a/src/test/kotlin/org/zaikorea/zaiclienttest/ZaiClientBatchKotlinTest.kt
+++ b/src/test/kotlin/org/zaikorea/zaiclienttest/ZaiClientBatchKotlinTest.kt
@@ -559,3 +559,4 @@ class ZaiClientBatchKotlinTest {
                 return utcnow.toString()
             }
     }
+}


### PR DESCRIPTION
`RecommendationResponse`의 `getMetadata` 메서드의 return type을 `String` -> `Map<String, Object>`으로 변경했습니다.