### PR TITLE
[hotfix] Remove additional validation of custom recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation 'com.github.zaikorea:zaiclient-java:v3.2.1'
+  implementation 'com.github.zaikorea:zaiclient-java:v3.2.2'
 }
 ```
 
@@ -50,7 +50,7 @@ Dependency를 추가합니다.
 
 ```css
 dependencies {
-  implementation("com.github.zaikorea:zaiclient-java:v3.2.1")
+  implementation("com.github.zaikorea:zaiclient-java:v3.2.2")
 }
 ```
 
@@ -71,6 +71,6 @@ dependencies {
   <dependency>
     <groupId>com.github.zaikorea</groupId>
     <artifactId>zaiclient-java</artifactId>
-    <version>v3.2.1</version>
+    <version>v3.2.2</version>
   </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zaikorea</groupId>
     <artifactId>zaiclient</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 
     <name>zaiclient</name>
     <url>https://github.com/zaikorea/zaiclient</url>

--- a/src/main/java/org/zaikorea/zaiclient/request/recommendations/GetCustomRecommendation.java
+++ b/src/main/java/org/zaikorea/zaiclient/request/recommendations/GetCustomRecommendation.java
@@ -20,10 +20,6 @@ public class GetCustomRecommendation extends RecommendationRequest {
     private static final List<String> DEFAULT_ITEM_IDS = null;
 
     public GetCustomRecommendation(Builder builder) {
-        // Additional validation
-        if (builder.userId == null && builder.itemId == null && builder.itemIds == null)
-            throw new IllegalArgumentException("At least one of userId, itemId, or itemIds must be provided.");
-
         this.recQuery = new RecommendationQuery()
                 .setUserId(builder.userId)
                 .setItemId(builder.itemId)

--- a/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetCustomRecommendationTest.java
+++ b/src/test/java/org/zaikorea/zaiclienttest/ZaiClientGetCustomRecommendationTest.java
@@ -47,7 +47,6 @@ public class ZaiClientGetCustomRecommendationTest {
     private static final String recLogLimitKey = "limit";
     private static final String recLogItemIdsKey = "item_ids";
 
-    private static final String illegalAccessExceptionMessage = "At least one of userId, itemId, or itemIds must be provided.";
     private static final String nullLimitExceptionMessage = "The value of limit must not be null";
 
     private ZaiClient testClientToDevEndpoint; // TODO: Figure out to map dev endpoint with environment variable
@@ -391,20 +390,27 @@ public class ZaiClientGetCustomRecommendationTest {
         }
     }
 
-    // Unhappy path
     @Test
-    public void testGetCustomRecommendationWithoutAnyInput() { // No ItemId, No UserId, No ItemIds
+    public void testGetCustomRecommendation_7() {
+        int limit = TestUtils.generateRandomInteger(1, 10);
+        String recommendationType = "category-widget2-recommendations";
+
+        RecommendationRequest recommendation = new GetCustomRecommendation.Builder(recommendationType)
+                .limit(limit)
+                .build();
+
         try {
-            new GetCustomRecommendation.Builder("homepage-main-recommendations")
-                    .build();
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals(illegalAccessExceptionMessage, e.getMessage());
-        } catch (Error e) {
+            Map<String, Object> expectedMetadata = new HashMap<String, Object>();
+            expectedMetadata.put("limit", limit);
+            expectedMetadata.put("recommendation_type", recommendationType);
+            expectedMetadata.put("call_type", recommendationType);
+            checkSuccessfulGetCustomRecommendation(recommendation, expectedMetadata);
+        } catch (Exception e) {
             fail();
         }
     }
 
+    // Unhappy path
     @Test
     public void testGetCustomRecommendationWithoutLimit() {
         int itemCount = TestUtils.generateRandomInteger(1, 10);


### PR DESCRIPTION
- `GetCustomRecommendation`의 `userId`, `itemId`, `itemIds`가 모두 `null`이어도 valid한 요청으로 처리하도록 수정했습니다.